### PR TITLE
Change `getGeometricCommunityForecast` to provide probability, not odds

### DIFF
--- a/lib/_utils_common.ts
+++ b/lib/_utils_common.ts
@@ -65,16 +65,17 @@ export function getGeometricCommunityForecast(
     question.forecasts,
     date,
   ).map(([, forecast]) => nudgeAwayFromZeroOrOne(forecast.forecast.toNumber()))
-  // sum each forecast
+
+  // geometric mean of n elements is prod(N)^(1/n)
   const productOfForecasts: number = uptoDateForecasts.reduce(
-    (acc, forecast) => acc * (forecast / (1 - forecast)),
+    (acc, forecast) => acc * forecast,
     1,
   )
-  const geoMeanOfOdds = Math.pow(
+
+  return Math.pow(
     productOfForecasts,
     1 / uptoDateForecasts.length,
   )
-  return geoMeanOfOdds / (1 + geoMeanOfOdds)
 }
 
 export function getCommunityForecast(


### PR DESCRIPTION
Community predictions are all wrong in the UI because a previous commit changed probability to odds. This fixes that.

![image](https://github.com/Sage-Future/fatebook/assets/32420055/9e87ca53-034a-415d-bfda-058de76e6eeb)
