### PR TITLE
adds onChange event to BinaryQuestion datepicker that sets value of r…

### DIFF
--- a/components/questions/question-types/BinaryQuestion.tsx
+++ b/components/questions/question-types/BinaryQuestion.tsx
@@ -101,13 +101,7 @@ export function BinaryQuestion({
                 )}
                 onKeyDown={onDateKeydown}
                 onMouseDown={(e) => e.stopPropagation()}
-                onChange={(e) => {
-                  setValue("resolveBy", e.currentTarget.value)
-                }}
-                ref={(e) => {
-                  resolveByInputRef.current = e
-                  register("resolveBy", { required: true }).ref(e)
-                }}
+                {...register("resolveBy", { required: true })}
               />
               <span className="italic text-neutral-400 text-sm p-1">
                 {!resolveByButtons && (

--- a/components/questions/question-types/BinaryQuestion.tsx
+++ b/components/questions/question-types/BinaryQuestion.tsx
@@ -101,6 +101,9 @@ export function BinaryQuestion({
                 )}
                 onKeyDown={onDateKeydown}
                 onMouseDown={(e) => e.stopPropagation()}
+                onChange={(e) => {
+                  setValue("resolveBy", e.currentTarget.value)
+                }}
                 ref={(e) => {
                   resolveByInputRef.current = e
                   register("resolveBy", { required: true }).ref(e)

--- a/components/questions/question-types/BinaryQuestion.tsx
+++ b/components/questions/question-types/BinaryQuestion.tsx
@@ -1,9 +1,9 @@
-import { KeyboardEvent, useEffect, useRef } from "react"
 import clsx from "clsx"
-import { FormattedDate } from "../../ui/FormattedDate"
-import { InfoButton } from "../../ui/InfoButton"
+import { KeyboardEvent, useEffect, useRef } from "react"
 import { getDateYYYYMMDD, tomorrowDate } from "../../../lib/_utils_common"
 import { utcDateStrToLocalDate } from "../../../lib/web/utils"
+import { FormattedDate } from "../../ui/FormattedDate"
+import { InfoButton } from "../../ui/InfoButton"
 import { QuestionTypeProps } from "./question-types"
 
 interface BinaryQuestionProps extends QuestionTypeProps {}
@@ -53,6 +53,7 @@ export function BinaryQuestion({
     }
   }
 
+  const resolveByRegister = register("resolveBy", { required: true })
   const resolveByInputRef = useRef<HTMLInputElement | null>(null)
 
   useEffect(() => {
@@ -101,7 +102,11 @@ export function BinaryQuestion({
                 )}
                 onKeyDown={onDateKeydown}
                 onMouseDown={(e) => e.stopPropagation()}
-                {...register("resolveBy", { required: true })}
+                {...resolveByRegister}
+                ref={(e) => {
+                  resolveByInputRef.current = e
+                  resolveByRegister.ref(e)
+                }}
               />
               <span className="italic text-neutral-400 text-sm p-1">
                 {!resolveByButtons && (


### PR DESCRIPTION
…esolveBy

# Pull Request: Fix datepicker text

## Related Issue
Bugfix for report made in Discord

## Changes Made
- Adds `onChange` event listener to datepicker in BinaryQuestion component that updates the value for `resolveBy`. I thought that registered the field would do this for us already, so not entirely sure why it isn't. 

## Testing
Tested on localhost, I can create and resolve questions correctly and date values look correct.
