### PR TITLE
Don't hide forecasts on resolved questions

### DIFF
--- a/lib/_utils_common.ts
+++ b/lib/_utils_common.ts
@@ -12,7 +12,7 @@ export function forecastsAreHidden(
   question: QuestionWithForecasts,
   userId: string | undefined,
 ) {
-  return (
+  return !question.resolved && (
     (!!question.hideForecastsUntil &&
       question.hideForecastsUntil.getTime() > Date.now()) ||
     (!!question.hideForecastsUntilPrediction &&


### PR DESCRIPTION
## Related Issue

[If applicable, link to the related issue. Use GitHub's syntax to automatically close the issue when the PR is merged]
Closes #34

## Testing

Tested logged in and logged out, on a resolved question and an unresolved one.
