### PR TITLE
Wrap response with scrubber function

### DIFF
--- a/lib/web/question_router.ts
+++ b/lib/web/question_router.ts
@@ -205,7 +205,13 @@ export const questionRouter = router({
         where: { id: ctx.userId || "NO MATCH" },
       })
       assertHasAccess(ctx, question, user)
-      return question && scrubHiddenForecastsFromQuestion(question, ctx.userId)
+      return (
+        question &&
+        scrubHiddenForecastsAndSensitiveDetailsFromQuestion(
+          question,
+          ctx.userId,
+        )
+      )
     }),
 
   getQuestionsUserCreatedOrForecastedOnOrIsSharedWith: publicProcedure
@@ -1452,7 +1458,9 @@ async function getQuestionsUserCreatedOrForecastedOnOrIsSharedWith(
 
   return {
     items: questions
-      .map((q) => scrubHiddenForecastsFromQuestion(q, ctx.userId))
+      .map((q) =>
+        scrubHiddenForecastsAndSensitiveDetailsFromQuestion(q, ctx.userId),
+      )
       // don't include the extra one - it's just to see if there's another page
       .slice(0, limit),
 
@@ -1556,10 +1564,10 @@ export function assertHasAccess(
   }
 }
 
-export function scrubHiddenForecastsFromQuestion<
+export function scrubHiddenForecastsAndSensitiveDetailsFromQuestion<
   QuestionX extends QuestionWithForecasts,
 >(question: QuestionX, userId: string | undefined) {
-  question = scrubApiKeyPropertyRecursive(question)
+  question = scrubApiKeyPropertyRecursive(question, ["email", "discordUserId"])
 
   if (!forecastsAreHidden(question, userId)) {
     return question

--- a/lib/web/question_router.ts
+++ b/lib/web/question_router.ts
@@ -226,9 +226,19 @@ export const questionRouter = router({
         return null
       }
 
-      return await getQuestionsUserCreatedOrForecastedOnOrIsSharedWith(
-        input,
-        ctx,
+      return scrubApiKeyPropertyRecursive(
+        await getQuestionsUserCreatedOrForecastedOnOrIsSharedWith(
+          input,
+          ctx
+        ),
+        [
+          "email",
+          "discordUserId",
+          "apiKey",
+          "unsubscribedFromEmailsAt",
+          "emailVerified",
+          "staleReminder",
+        ],
       )
     }),
 

--- a/lib/web/question_router.ts
+++ b/lib/web/question_router.ts
@@ -227,10 +227,7 @@ export const questionRouter = router({
       }
 
       return scrubApiKeyPropertyRecursive(
-        await getQuestionsUserCreatedOrForecastedOnOrIsSharedWith(
-          input,
-          ctx
-        ),
+        await getQuestionsUserCreatedOrForecastedOnOrIsSharedWith(input, ctx),
         [
           "email",
           "discordUserId",
@@ -1384,7 +1381,7 @@ async function getQuestionsUserCreatedOrForecastedOnOrIsSharedWith(
           : {},
         input.extraFilters?.unresolved
           ? {
-              resolution: null
+              resolution: null,
             }
           : {},
         input.extraFilters?.readyToResolve

--- a/pages/api/v0/getQuestion.ts
+++ b/pages/api/v0/getQuestion.ts
@@ -5,7 +5,7 @@ import prisma from "../../../lib/prisma"
 import {
   assertHasAccess,
   scrubApiKeyPropertyRecursive,
-  scrubHiddenForecastsFromQuestion,
+  scrubHiddenForecastsAndSensitiveDetailsFromQuestion,
 } from "../../../lib/web/question_router"
 import { authOptions } from "../auth/[...nextauth]"
 
@@ -119,8 +119,10 @@ const getQuestionPublicApi = async (req: Request, res: NextApiResponse) => {
   }
 
   const userName = question!.user.name
-  const prediction = getMostRecentForecastForUser(question!, question!.userId)
-    ?.forecast
+  const prediction = getMostRecentForecastForUser(
+    question!,
+    question!.userId,
+  )?.forecast
 
   if (req.query.conciseQuestionDetails) {
     res.status(200).json({
@@ -138,7 +140,7 @@ const getQuestionPublicApi = async (req: Request, res: NextApiResponse) => {
           resolution: question?.resolution,
           resolveBy: question?.resolveBy,
           resolvedAt: question?.resolvedAt,
-          forecasts: scrubHiddenForecastsFromQuestion(
+          forecasts: scrubHiddenForecastsAndSensitiveDetailsFromQuestion(
             question,
             authedUserId,
           )?.forecasts.map((f) => ({


### PR DESCRIPTION
# Pull Request: Scrub personal data from questions response


## Changes Made
- Wrapped response from `question.getQuestionsUserCreatedOrForecastedOnOrIsSharedWith` with a scrubber function. There may be more places this needs to be applied to, but this should remove emails and other personal data from anything that uses the Questions component.


## Testing

Tested locally that responses on the public predictions page now return null for emails and some other fields.

## Risks
There may be other responses that need to be scrubbed in a similar way. This is also intended as a quick fix for the immediate issue - but for reducing the risk of this happening again in future, I think we should consider having clearer models of what we need in the response from the DB. 