### PR TITLE
feat: expands searchString in ExtraFilters to include tags.

### DIFF
--- a/lib/web/question_router.ts
+++ b/lib/web/question_router.ts
@@ -1501,7 +1501,7 @@ async function getQuestionsUserCreatedOrForecastedOnOrIsSharedWith(
                           contains: input.extraFilters.searchString,
                           mode: "insensitive",
                         },
-                        userId: ctx.userId, 
+                        userId: userIdIfAuthed,
                       },
                     },
                   },

--- a/lib/web/question_router.ts
+++ b/lib/web/question_router.ts
@@ -1501,6 +1501,7 @@ async function getQuestionsUserCreatedOrForecastedOnOrIsSharedWith(
                           contains: input.extraFilters.searchString,
                           mode: "insensitive",
                         },
+                        userId: ctx.userId, 
                       },
                     },
                   },

--- a/lib/web/question_router.ts
+++ b/lib/web/question_router.ts
@@ -108,7 +108,7 @@ const zodExtraFilters = z.object({
     })
     .optional(),
   searchString: z
-    .string({ description: "Only get questions containing this search string" })
+    .string({ description: "Only get questions or tags containing this search string" })
     .optional(),
   theirUserId: z
     .string({
@@ -1488,6 +1488,16 @@ async function getQuestionsUserCreatedOrForecastedOnOrIsSharedWith(
                     comments: {
                       some: {
                         comment: {
+                          contains: input.extraFilters.searchString,
+                          mode: "insensitive",
+                        },
+                      },
+                    },
+                  },
+                  {
+                    tags: {
+                      some: {
+                        name: {
                           contains: input.extraFilters.searchString,
                           mode: "insensitive",
                         },


### PR DESCRIPTION
# Pull Request: expands searchString in ExtraFilters to include tags

## Related Issue
https://app.asana.com/0/1208202570969977/1208203484336793

## Changes Made
- Added additional parameters to TRPC query used by the search box in the UI

## Testing
Low risk change, tested locally and works as expected:
<img width="685" alt="Screenshot 2024-09-03 at 12 02 11" src="https://github.com/user-attachments/assets/c592d048-bd55-441b-bba8-868148f22c3c">

