### PR TITLE
Removes overlapping member names from team page

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,9 +7,8 @@ Closes #[Issue Number]
 
 ## Changes Made
 
-[List the key changes made in this PR. Use bullet points for clarity]
+## [List the key changes made in this PR. Use bullet points for clarity]
 
--
 -
 
 ## Testing

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ localhost.pem
 
 .env*.local
 .idea
+
+# Don't commit scripts in root dir
+*.py

--- a/pages/team/[list_id].tsx
+++ b/pages/team/[list_id].tsx
@@ -71,10 +71,10 @@ export default function ListPage() {
                   className="bg-white px-2 py-1.5 rounded-full outline outline-1 outline-neutral-200 hover:bg-neutral-100"
                 />
               </span>
-              <div className="block">
+              <div>
                 <span>Team members:</span>
                 {listQ.data.users.length > 0 ? (
-                  <div className="flex flex-wrap gap-2 mt-1 max-w-2xl">
+                  <div className="flex flex-wrap gap-2 mt-1 max-w-full">
                     {listQ.data.users.map((u) => (
                       <Username
                         key={u.id}

--- a/pages/team/[list_id].tsx
+++ b/pages/team/[list_id].tsx
@@ -65,27 +65,29 @@ export default function ListPage() {
                 onDelete={() => void router.push("/")}
               />
               <span className="block">
-                A team created by{" "}
+                A team created by:{" "}
                 <Username
                   user={listQ.data.author}
                   className="bg-white px-2 py-1.5 rounded-full outline outline-1 outline-neutral-200 hover:bg-neutral-100"
                 />
               </span>
-              <span className="block">
-                Team members{" "}
+              <div className="block">
+                <span>Team members:</span>
                 {listQ.data.users.length > 0 ? (
-                  listQ.data.users.map((u) => (
-                    <Username
-                      key={u.id}
-                      user={u}
-                      className="bg-white px-2 py-1.5 rounded-full outline outline-1 outline-neutral-200 ml-2 hover:bg-neutral-100"
-                      unknownUserText="Invited user"
-                    />
-                  ))
+                  <div className="flex flex-wrap gap-2 mt-1 max-w-2xl">
+                    {listQ.data.users.map((u) => (
+                      <Username
+                        key={u.id}
+                        user={u}
+                        className="bg-white px-2 py-1.5 rounded-full outline outline-1 outline-neutral-200 hover:bg-neutral-100 leading-8"
+                        unknownUserText="Invited user"
+                      />
+                    ))}
+                  </div>
                 ) : (
                   <span className="italic">none</span>
                 )}
-              </span>
+              </div>
               {listQ.data.emailDomains.length > 0 && (
                 <span className="block">
                   Email domains {listQ.data.emailDomains.join(", ")}


### PR DESCRIPTION
# Pull Request: Removes overlapping member names from team page

## Related Issue
Asana ref: https://app.asana.com/0/1208202570969977/1208203484337881/f

## Changes Made
- Added a wrapping div for team member blocks which allows for a flex-box layout

## Testing
Tested locally, low-risk change. Exported component is only used in one place.
<img width="732" alt="Screenshot 2024-09-04 at 12 53 43" src="https://github.com/user-attachments/assets/b500bbc5-8a02-4ba0-a1f3-130d5e86e6de">
<img width="373" alt="Screenshot 2024-09-04 at 12 54 11" src="https://github.com/user-attachments/assets/43f69961-526b-4a9c-8297-0e3527170687">

