### PR TITLE
Fix long comments not wrapping properly in Firefox

### DIFF
--- a/components/questions/QuestionDetails.tsx
+++ b/components/questions/QuestionDetails.tsx
@@ -177,7 +177,7 @@ function EventsLog({ question }: { question: QuestionWithStandardIncludes }) {
               <FormattedDate date={c.createdAt} className="my-auto" />
               <DeleteCommentOverflow question={question} comment={c} />
             </span>
-            <span className="md:pl-7 col-span-4 -mt-1 break-words overflow-x-auto whitespace-pre-line">
+            <span className="md:pl-7 col-span-4 -mt-1 break-all min-w-0 whitespace-pre-line">
               {c.comment}
             </span>
           </Fragment>


### PR DESCRIPTION
# Pull Request: Fix long comments not wrapping properly in Firefox

## Related Issue
Asana: https://app.asana.com/0/1208202570969977/1208235360283982/f

## Changes Made
- Updated classes in event log comment container

## Testing
Low risk change, tested locally in Chrome and Firefox
Chrome:
<img width="692" alt="Screenshot 2024-09-06 at 16 52 00" src="https://github.com/user-attachments/assets/ee06b292-795a-4b5f-9d85-15ef4aead1c8">
Firefox:
<img width="692" alt="Screenshot 2024-09-06 at 16 52 27" src="https://github.com/user-attachments/assets/aec4d99d-cda0-48dd-a11d-a8266e9a9a44">
