### PR TITLE
Fix: Only collapse TrackRecord if the button to uncollapse it is present

### DIFF
--- a/components/TrackRecord.tsx
+++ b/components/TrackRecord.tsx
@@ -32,9 +32,10 @@ export function TrackRecord({
   const router = useRouter()
   const showCollapseButton = router.pathname === "/"
   const [isCollapsed, setIsCollapsed] = useState(
-    typeof window !== "undefined" && isThisUser
-      ? JSON.parse(localStorage.getItem("isCollapsed") || "false")
-      : false,
+    showCollapseButton &&
+      (typeof window !== "undefined" && isThisUser
+        ? JSON.parse(localStorage.getItem("isCollapsed") || "false")
+        : false),
   )
 
   const userName = api.getUserInfo.useQuery(


### PR DESCRIPTION
# Pull Request: Only collapse TrackRecord if the button to uncollapse it is present

## Related Issue

N/A

## Changes Made

Toggling the collapsed state of `TrackRecord` sets a localStorage item to remember this state between page loads. Previously it would use this state even if the button to uncollapse it was not present. This meant that `TrackRecord` could end up collapsed on the stats page with no obvious reason for this. This changes it to only allow collapsing if `showCollapseButton` is true.  Before/after:
<img width="1221" alt="Screenshot 2024-09-12 at 19 53 32" src="https://github.com/user-attachments/assets/5dee47ee-f003-4f7d-8b19-404de8dc110d">
<img width="1221" alt="Screenshot 2024-09-12 at 19 53 26" src="https://github.com/user-attachments/assets/5a0e6af0-b687-4874-959c-b10735282e06">


## Testing


