### PR TITLE
Fix: Parse resolveBy correctly from cached_question_content

### DIFF
--- a/components/predict-form/Predict.tsx
+++ b/components/predict-form/Predict.tsx
@@ -379,7 +379,10 @@ export function Predict({
 
       if (cachedQuestion.resolveBy) {
         try {
-          setValue("resolveBy", getDateYYYYMMDD(cachedQuestion.resolveBy))
+          setValue(
+            "resolveBy",
+            getDateYYYYMMDD(utcDateStrToLocalDate(cachedQuestion.resolveBy)),
+          )
         } catch {
           // just skip it if we can't parse the date
         }


### PR DESCRIPTION
# Pull Request: Parse resolveBy correctly from cached_question_content

## Related Issue

N/A

## Changes Made

Previously if you wrote a question logged out and then clicked "Sign up to predict" the resolveBy date wouldn't be carried over. This was because it was treated as a date rather than a string when attempting to parse it. This fixes that.

## Testing

