### PR TITLE
Moves question picker above question input, changes buttons to be visually subtler

### DIFF
--- a/components/predict-form/Predict.tsx
+++ b/components/predict-form/Predict.tsx
@@ -366,6 +366,11 @@ export function Predict({
           <form onSubmit={void handleSubmit(onSubmit)}>
             <div className="w-full ">
               <div className="relative">
+                <QuestionTypeSelect
+                  questionType={questionType}
+                  setQuestionType={setQuestionType}
+                />
+
                 <TextareaAutosize
                   className={clsx(
                     "w-full border-2 border-neutral-300 rounded-md resize-none shadow-lg focus:shadow-xl transition-shadow mb-2",
@@ -397,7 +402,7 @@ export function Predict({
                   <button
                     tabIndex={-1}
                     className={clsx(
-                      "inline-flex align-middle justify-center text-center btn btn-circle aspect-square absolute right-3 top-calc-50-minus-05rem hover:opacity-100 !-translate-y-1/2",
+                      "inline-flex align-middle justify-center text-center btn btn-circle aspect-square absolute right-3 top-calc-50-plus-1rem hover:opacity-100 !-translate-y-1/2",
                       showSuggestions ? "btn-active" : "btn-ghost",
                       !!question && !showSuggestions
                         ? "opacity-20"
@@ -447,11 +452,6 @@ export function Predict({
                 Tagging this question: {tagsPreview.join(", ")}
               </div>
             )}
-
-            <QuestionTypeSelect
-              questionType={questionType}
-              setQuestionType={setQuestionType}
-            />
 
             {(() => {
               switch (questionType) {

--- a/components/predict-form/QuestionTypeSelect.tsx
+++ b/components/predict-form/QuestionTypeSelect.tsx
@@ -15,9 +15,7 @@ export function QuestionTypeSelect({
       <button
         className={clsx(
           "btn",
-          questionType === QuestionType.BINARY
-            ? "btn-primary"
-            : "text-neutral-500",
+          questionType === QuestionType.BINARY ? "" : "btn-ghost",
         )}
         onClick={(e) => {
           e.preventDefault()
@@ -29,9 +27,7 @@ export function QuestionTypeSelect({
       <button
         className={clsx(
           "btn",
-          questionType === QuestionType.MULTIPLE_CHOICE
-            ? "btn-primary"
-            : "text-neutral-500",
+          questionType === QuestionType.MULTIPLE_CHOICE ? "" : "btn-ghost",
         )}
         onClick={(e) => {
           e.preventDefault()

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -12,7 +12,7 @@ export default {
         sans: ["Inter var", ...defaultTheme.fontFamily.sans],
       },
       inset: {
-        "calc-50-minus-05rem": "calc(50% - 0.5rem)",
+        "calc-50-plus-1rem": "calc(50% + 1rem)",
       },
     },
   },


### PR DESCRIPTION
# Pull Request: Moves question picker above question input, changes buttons to be visually subtler

## Related Issue
None - AB commented in Slack

## Changes Made
- Changes question picker component to be above question input in predict component
- Changes active type to be regular `btn` and inactive types to be `btn-ghost`

## Testing
Tested locally and in preview, see screenshots below
<img width="692" alt="Screenshot 2024-09-19 at 10 10 06" src="https://github.com/user-attachments/assets/65207a2d-b027-41e4-909e-4478c95dc807">
<img width="391" alt="Screenshot 2024-09-19 at 10 10 20" src="https://github.com/user-attachments/assets/d79d9148-5d36-41d8-ad90-39f7ef726450">
<img width="766" alt="Screenshot 2024-09-19 at 10 55 38" src="https://github.com/user-attachments/assets/0b74dbaa-7578-4137-8aa9-57b8811323c2">
<img width="330" alt="Screenshot 2024-09-19 at 10 55 50" src="https://github.com/user-attachments/assets/2e7114e3-551f-4f16-97c5-8f2321ae2b99">
<img width="330" alt="Screenshot 2024-09-19 at 10 59 05" src="https://github.com/user-attachments/assets/ee725247-0437-488c-bd9b-488511d4e803">

