### PR TITLE
Freezes option order for MCQs

### DIFF
--- a/components/questions/Question.tsx
+++ b/components/questions/Question.tsx
@@ -9,7 +9,7 @@ import {
 import clsx from "clsx"
 import { motion } from "framer-motion"
 import Link from "next/link"
-import { useMemo, useState } from "react"
+import { useState } from "react"
 import { ErrorBoundary } from "react-error-boundary"
 import { QuestionWithStandardIncludes } from "../../prisma/additional"
 import { FormattedDate } from "../ui/FormattedDate"

--- a/components/questions/Question.tsx
+++ b/components/questions/Question.tsx
@@ -71,25 +71,6 @@ export function Question({
       }, 0) ?? 0 // Use nullish coalescing operator to default to 0 if reduce returns undefined
   }
 
-  const sortedOptions = useMemo(() => {
-    if (question.type !== "MULTIPLE_CHOICE") {
-      return []
-    }
-    return [...question.options!].sort((a, b) => {
-      const aForecast = a.forecasts.find((f) => f.userId === userId)
-      const bForecast = b.forecasts.find((f) => f.userId === userId)
-
-      const aValue = aForecast ? aForecast.forecast.toNumber() : 0
-      const bValue = bForecast ? bForecast.forecast.toNumber() : 0
-
-      if (bValue === aValue) {
-        return question.options!.indexOf(a) - question.options!.indexOf(b)
-      }
-
-      return bValue - aValue
-    })
-  }, [question.options, question.type, userId])
-
   return (
     <ErrorBoundary fallback={<div>Something went wrong</div>}>
       <motion.div
@@ -158,11 +139,11 @@ export function Question({
                 />
               )}
             </span>
-            {question.type === "MULTIPLE_CHOICE" && (
+            {question.type === "MULTIPLE_CHOICE" && question.options && (
               <div className="contents">
-                {sortedOptions.map((option, index) => (
+                {question.options.map((option) => (
                   <QuestionDetailsOption
-                    key={index}
+                    key={option.id}
                     option={option}
                     question={question}
                     autoFocus={alwaysExpand}


### PR DESCRIPTION
# Pull Request: Freezes option order for MCQs

## Related Issue
Asana: [https://app.asana.com/0/1208202570969977/1208351783709432/f](https://app.asana.com/0/1208202570969977/1208351783709432/f)

## Changes Made
- Removes `sortedOptions` variable from question.tsx
- Changes option mapping to use `question.options`

## Testing
Tested in local/preview
<img width="697" alt="Screenshot 2024-09-19 at 17 14 27" src="https://github.com/user-attachments/assets/4c7c3b6e-5d59-4f22-9534-fb9f6d766a3b">

