### PR TITLE
Add number of tagged questions to tag picker

### DIFF
--- a/components/questions/TagsSelect.tsx
+++ b/components/questions/TagsSelect.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import clsx from "clsx"
 import Link from "next/link"
 import { useState } from "react"
@@ -5,6 +6,15 @@ import Select, { components } from "react-select"
 import CreatableSelect from "react-select/creatable"
 import { api } from "../../lib/web/trpc"
 import { getTagPageUrl } from "../../pages/tag/[tag]"
+
+// Add this interface near the top of the file, after the imports
+interface MultiValueLabelProps {
+  data: { value: string }
+  questionCount?: number
+  innerProps: any
+  selectProps: any
+  [key: string]: any
+}
 
 export function TagsSelect({
   tags,
@@ -110,21 +120,18 @@ export function TagsSelect({
   )
 }
 
-function MultiValueLabel(props: {
-  data: { value: string }
-  questionCount?: number
-  [key: string]: any
-}) {
+// Update the MultiValueLabel function definition
+function MultiValueLabel({ data, questionCount, innerProps, selectProps, ...props }: MultiValueLabelProps) {
   return (
     <Link
-      href={getTagPageUrl(props.data.value)}
+      href={getTagPageUrl(data.value)}
       onMouseDown={(e) => e.stopPropagation()}
     >
-      <components.MultiValueLabel {...(props as unknown as any)}>
-        {props.data.value}
-        {props.questionCount !== undefined && (
+      <components.MultiValueLabel {...props} data={data} innerProps={innerProps} selectProps={selectProps}>
+        {data.value}
+        {questionCount !== undefined && (
           <span className="ml-1 text-xs text-gray-500">
-            ({props.questionCount})
+            ({questionCount})
           </span>
         )}
       </components.MultiValueLabel>

--- a/components/questions/TagsSelect.tsx
+++ b/components/questions/TagsSelect.tsx
@@ -44,7 +44,10 @@ export function TagsSelect({
               }
             : undefined
         }
-        options={allTags.map((tag) => ({ label: tag.name, value: tag.name }))}
+        options={allTags.map((tag) => ({
+          label: `${tag.name} (${tag.questionCount})`,
+          value: tag.name,
+        }))}
         hideSelectedOptions={true}
         formatCreateLabel={
           allowCreation
@@ -85,7 +88,11 @@ export function TagsSelect({
         }
         closeMenuOnSelect={false}
         components={{
-          MultiValueLabel,
+          MultiValueLabel: (props) => (
+            <MultiValueLabel {...props} questionCount={
+              allTags.find(t => t.name === props.data.value)?.questionCount
+            } />
+          ),
           // hide the dropdown chevron
           // eslint-disable-next-line @typescript-eslint/naming-convention
           DropdownIndicator: () => null,
@@ -105,6 +112,7 @@ export function TagsSelect({
 
 function MultiValueLabel(props: {
   data: { value: string }
+  questionCount?: number
   [key: string]: any
 }) {
   return (
@@ -112,7 +120,14 @@ function MultiValueLabel(props: {
       href={getTagPageUrl(props.data.value)}
       onMouseDown={(e) => e.stopPropagation()}
     >
-      <components.MultiValueLabel {...(props as unknown as any)} />
+      <components.MultiValueLabel {...(props as unknown as any)}>
+        {props.data.value}
+        {props.questionCount !== undefined && (
+          <span className="ml-1 text-xs text-gray-500">
+            ({props.questionCount})
+          </span>
+        )}
+      </components.MultiValueLabel>
     </Link>
   )
 }

--- a/components/questions/TagsSelect.tsx
+++ b/components/questions/TagsSelect.tsx
@@ -44,10 +44,12 @@ export function TagsSelect({
               }
             : undefined
         }
-        options={allTags.map((tag) => ({
-          label: `${tag.name} (${tag.questionCount})`,
-          value: tag.name,
-        }))}
+        options={allTags
+          .sort((a, b) => b.questionCount - a.questionCount) // Sort tags by questionCount descending
+          .map((tag) => ({
+            label: `${tag.name} (${tag.questionCount})`,
+            value: tag.name,
+          }))}
         hideSelectedOptions={true}
         formatCreateLabel={
           allowCreation

--- a/components/questions/TagsSelect.tsx
+++ b/components/questions/TagsSelect.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/prop-types */
 import clsx from "clsx"
 import Link from "next/link"
 import { useState } from "react"
@@ -6,15 +5,6 @@ import Select, { components } from "react-select"
 import CreatableSelect from "react-select/creatable"
 import { api } from "../../lib/web/trpc"
 import { getTagPageUrl } from "../../pages/tag/[tag]"
-
-// Add this interface near the top of the file, after the imports
-interface MultiValueLabelProps {
-  data: { value: string }
-  questionCount?: number
-  innerProps: any
-  selectProps: any
-  [key: string]: any
-}
 
 export function TagsSelect({
   tags,
@@ -98,11 +88,7 @@ export function TagsSelect({
         }
         closeMenuOnSelect={false}
         components={{
-          MultiValueLabel: (props) => (
-            <MultiValueLabel {...props} questionCount={
-              allTags.find(t => t.name === props.data.value)?.questionCount
-            } />
-          ),
+          MultiValueLabel,
           // hide the dropdown chevron
           // eslint-disable-next-line @typescript-eslint/naming-convention
           DropdownIndicator: () => null,
@@ -120,19 +106,20 @@ export function TagsSelect({
   )
 }
 
-// Update the MultiValueLabel function definition
-function MultiValueLabel({ data, questionCount, innerProps, selectProps, ...props }: MultiValueLabelProps) {
+function MultiValueLabel(props: {
+  data: { value: string }
+  questionCount?: number
+  [key: string]: any
+}) {
   return (
     <Link
-      href={getTagPageUrl(data.value)}
+      href={getTagPageUrl(props.data.value)}
       onMouseDown={(e) => e.stopPropagation()}
     >
-      <components.MultiValueLabel {...props} data={data} innerProps={innerProps} selectProps={selectProps}>
-        {data.value}
-        {questionCount !== undefined && (
-          <span className="ml-1 text-xs text-gray-500">
-            ({questionCount})
-          </span>
+      <components.MultiValueLabel {...(props as unknown as any)}>
+        {props.data.value}
+        {props.questionCount !== undefined && (
+          <span className="ml-1 text-xs text-gray-500">({props.questionCount})</span>
         )}
       </components.MultiValueLabel>
     </Link>

--- a/lib/web/tags_router.ts
+++ b/lib/web/tags_router.ts
@@ -14,7 +14,16 @@ export const tagsRouter = router({
       where: {
         userId: ctx.userId,
       },
-    })
+      include: {
+        _count: {
+          select: { questions: true },
+        },
+      },
+    }).then(tags => tags.map(tag => ({
+      ...tag,
+      questionCount: tag._count.questions,
+      _count: undefined,
+    })))
   }),
 
   getByName: publicProcedure


### PR DESCRIPTION
# Pull Request: Add number of tagged questions to tag picker

## Related Issue
[Asana ref](https://app.asana.com/0/1208202570969977/1208351783709445/f)

## Changes Made
- Changes tags to be ordered by descending frequency
- Changes getAll tags procedure to include questionCount
- Changes label in TagsSelect component to include questionCount value

## Testing
Tested locally and preview for tag select in Question and Calibration components
<img width="666" alt="Screenshot 2024-09-20 at 12 59 09" src="https://github.com/user-attachments/assets/d6fe3ee3-2faf-44e4-8d62-89809487852c">
<img width="328" alt="Screenshot 2024-09-20 at 12 59 26" src="https://github.com/user-attachments/assets/a9e38e09-cf83-467b-953b-0175c76db9ad">

