### PR TITLE
Gracefully handles case where sync to slack fails because channel is archived

### DIFF
--- a/components/questions/TagsSelect.tsx
+++ b/components/questions/TagsSelect.tsx
@@ -61,11 +61,14 @@ export function TagsSelect({
             ? (inputValue) => `Add new tag "${inputValue}"`
             : undefined
         }
-        formatOptionLabel={(option: {
-          label: string
-          value: string
-          questionCount: number
-        }, { context }: { context: string }) => (
+        formatOptionLabel={(
+          option: {
+            label: string
+            value: string
+            questionCount: number
+          },
+          { context }: { context: string },
+        ) => (
           <div className="flex items-center justify-between w-full">
             <div className="flex items-center gap-1">
               <TagIcon className="text-neutral-400 w-4 h-4" />
@@ -73,7 +76,7 @@ export function TagsSelect({
                 {option.label}
               </span>
             </div>
-            {context !== 'value' && (
+            {context !== "value" && (
               <span className="bg-neutral-100 text-neutral-800 text-xs font-semibold px-2 py-0.5 rounded-full">
                 {option.questionCount}
               </span>

--- a/components/questions/UpdateableLatestForecast.tsx
+++ b/components/questions/UpdateableLatestForecast.tsx
@@ -164,7 +164,7 @@ export function UpdateableLatestForecast({
     <>
       <span
         className={clsx(
-          "mr-0.5 font-bold h-min focus-within:ring-indigo-800 ring-neutral-300 px-1 py-0.5 rounded-md shrink-0 relative flex",
+          "mr-0.5 font-bold h-min hover:ring-neutral-400 focus-within:ring-indigo-800 hover:focus-within:ring-indigo-800 ring-neutral-300 px-1 py-0.5 rounded-md shrink-0 relative flex",
           addForecast.isLoading && "opacity-50",
           hasResolution ? "text-neutral-600 ring-0" : "text-indigo-800 ring-2",
           errorMessage && "ring-red-500 focus-within:ring-red-500",

--- a/components/questions/UpdateableLatestForecast.tsx
+++ b/components/questions/UpdateableLatestForecast.tsx
@@ -164,10 +164,11 @@ export function UpdateableLatestForecast({
     <>
       <span
         className={clsx(
-          "mr-0.5 font-bold h-min hover:ring-neutral-400 focus-within:ring-indigo-800 hover:focus-within:ring-indigo-800 ring-neutral-300 px-1 py-0.5 rounded-md shrink-0 relative flex",
+          "mr-0.5 font-bold h-min hover:ring-neutral-400 focus-within:ring-indigo-800 hover:focus-within:ring-indigo-800 ring-neutral-300 px-1 py-0.5 rounded-md shrink-0 relative flex transition-all",
           addForecast.isLoading && "opacity-50",
           hasResolution ? "text-neutral-600 ring-0" : "text-indigo-800 ring-2",
-          errorMessage && "ring-red-500 focus-within:ring-red-500",
+          errorMessage &&
+            "ring-red-500 focus-within:ring-red-500 hover:ring-red-500 hover:focus-within:ring-red-500",
           small ? "text-xl" : "text-2xl",
         )}
         onClick={(e) => {

--- a/lib/interactive_handlers/postFromWeb.ts
+++ b/lib/interactive_handlers/postFromWeb.ts
@@ -265,12 +265,19 @@ export async function syncToSlackIfNeeded(
         where: { id: userId || "NO MATCH" },
       })
       if (user) {
-        await postQuestionToSlack({
-          questionId: question.id,
-          teamId: entity.syncToSlackTeamId,
-          channelId: entity.syncToSlackChannelId,
-          user,
-        })
+        try {
+          await postQuestionToSlack({
+            questionId: question.id,
+            teamId: entity.syncToSlackTeamId,
+            channelId: entity.syncToSlackChannelId,
+            user,
+          })
+        } catch (error) {
+          if (error instanceof Error && error.message.includes("is_archived")) {
+            throw new Error("slackSyncError: Channel is archived")
+          }
+          throw error
+        }
       }
     }
   }

--- a/lib/web/question_router.ts
+++ b/lib/web/question_router.ts
@@ -556,7 +556,20 @@ export const questionRouter = router({
         })
       }
 
-      await syncToSlackIfNeeded(question, ctx.userId)
+      try {
+        await syncToSlackIfNeeded(question, ctx.userId)
+      } catch (error) {
+        if (error instanceof Error && error.message.includes("is_archived")) {
+          // If the error is due to an archived Slack channel, handle it gracefully
+          return {
+            url: getQuestionUrl(question),
+            ...input,
+            slackSyncError: "archived_channel",
+          }
+        }
+        throw error
+      }
+
       return { url: getQuestionUrl(question), ...input }
     }),
 

--- a/lib/web/tags_router.ts
+++ b/lib/web/tags_router.ts
@@ -21,7 +21,7 @@ export const tagsRouter = router({
       },
     })
 
-    return tags.map(tag => ({
+    return tags.map((tag) => ({
       ...tag,
       questionCount: tag._count.questions,
       _count: undefined,

--- a/lib/web/trpc.ts
+++ b/lib/web/trpc.ts
@@ -1,4 +1,3 @@
-import React from "react"
 import { TRPCClientError, httpBatchLink } from "@trpc/client"
 import { createTRPCNext } from "@trpc/next"
 import { toast } from "react-hot-toast"

--- a/lib/web/trpc.ts
+++ b/lib/web/trpc.ts
@@ -1,9 +1,11 @@
+import React from "react"
 import { TRPCClientError, httpBatchLink } from "@trpc/client"
 import { createTRPCNext } from "@trpc/next"
 import { toast } from "react-hot-toast"
 import transformer from "trpc-transformer"
 import { AppRouter } from "./app_router"
 
+/** @jsxImportSource react */
 export function getClientBaseUrl(useRelativePath = true) {
   if (typeof window !== "undefined") {
     return useRelativePath ? "" : window.location.origin
@@ -77,6 +79,17 @@ export const api = createTRPCNext<AppRouter>({
               if (!(error instanceof TRPCClientError)) return false
               if (error?.data?.code === 404) return false
               else {
+                // display a different message when the error is due to a Slack channel being archived
+                if (error.message.includes("slackSyncError")) {
+                  toast.custom(
+                    "The Slack channel you tried to sync to has been archived. The question was still created successfully, however it was not posted to Slack.",
+                    {
+                      icon: "🚨",
+                      duration: 10000,
+                    },
+                  )
+                  return false
+                }
                 toast.error(
                   `Oops, something went wrong.` +
                     (process.env.NODE_ENV === "development"


### PR DESCRIPTION
# Pull Request: Gracefully handles case where sync to slack fails because channel is archived

## Related Issue
[Asana ref](https://app.asana.com/0/1208202570969977/1208351783709454/f)

## Changes Made
- Adds try/catch blocks to check if error when posting to slack API is `is_archived`
- Adds custom toast to show the user when this is the case

## Testing
Tested locally, pretty low risk change given no user has reported this to us and it's likely existed for months
<img width="876" alt="Screenshot 2024-09-20 at 17 51 42" src="https://github.com/user-attachments/assets/04243ea7-b98a-4362-8969-2ee1ff38ae4c">
