### PR TITLE
Adds TagsSelect component to Predict component

### DIFF
--- a/components/predict-form/Predict.tsx
+++ b/components/predict-form/Predict.tsx
@@ -25,6 +25,7 @@ import { QuestionTypeSelect } from "./QuestionTypeSelect"
 import BinaryQuestion from "./question-types/BinaryQuestion"
 import MultiChoiceQuestion from "./question-types/MultiChoiceQuestion"
 import { PredictFormType, usePredictForm } from "./PredictProvider"
+import { TagsSelect } from "../questions/TagsSelect"
 
 type CreateQuestionMutationOutput = NonNullable<
   ReturnType<typeof api.question.create.useMutation>["data"]
@@ -359,6 +360,9 @@ export function Predict({
     }
   }
 
+  // used to calculate width of TagsSelect menu
+  const containerRef = useRef<HTMLDivElement>(null);
+
   return (
     <div className="w-full">
       <ErrorBoundary fallback={<div>Something went wrong</div>}>
@@ -371,56 +375,97 @@ export function Predict({
                   setQuestionType={setQuestionType}
                 />
 
-                <TextareaAutosize
+                <div
+                  ref={containerRef}
                   className={clsx(
-                    "w-full border-2 border-neutral-300 rounded-md resize-none shadow-lg focus:shadow-xl transition-shadow mb-2",
-                    "focus:outline-indigo-700 placeholder:text-neutral-400",
-                    small
-                      ? "text-md py-2 pl-4 pr-16"
-                      : "text-xl py-4 pl-4 pr-16",
+                    "w-full border-2 border-neutral-300 rounded-md mb-2 bg-white shadow-lg relative z-20",
                   )}
-                  placeholder={
-                    placeholder || questionType === QuestionType.MULTIPLE_CHOICE
-                      ? "What day will my project be done by?"
-                      : "Will I finish my project by Friday?"
-                  }
-                  maxRows={15}
-                  onChange={(e) => {
-                    updateTagsPreview(e.currentTarget.value)
-                    void onChangeQuestion(e)
-                  }}
-                  onKeyDown={onEnterSubmit}
-                  defaultValue={questionDefaults?.title}
-                  onMouseDown={(e) => e.stopPropagation()}
-                  {...registerQuestion}
-                  onFocus={() => setQuestionInFocus(true)}
-                  onBlur={() => setQuestionInFocus(false)}
-                  ref={mergeRefs([textAreaRef, formRef])}
-                />
-
-                {showQuestionSuggestionsButton && (
-                  <button
-                    tabIndex={-1}
+                >
+                  <TextareaAutosize
                     className={clsx(
-                      "inline-flex align-middle justify-center text-center btn btn-circle aspect-square absolute right-3 top-[calc(50%+1rem)] hover:opacity-100 !-translate-y-1/2",
-                      showSuggestions ? "btn-active" : "btn-ghost",
-                      !!question && !showSuggestions
-                        ? "opacity-20"
-                        : "opacity-80",
-                      small && "btn-xs px-5",
+                      "w-full resize-none rounded-md p-4 -mb-2",
+                      "focus:outline-indigo-700 placeholder:text-neutral-400",
+                      small ? "text-md" : "text-xl",
                     )}
-                    onClick={(e) => {
-                      setShowSuggestions(!showSuggestions)
-                      e.preventDefault()
+                    placeholder={
+                      placeholder ||
+                      questionType === QuestionType.MULTIPLE_CHOICE
+                        ? "What day will my project be done by?"
+                        : "Will I finish my project by Friday? "
+                    }
+                    maxRows={15}
+                    onChange={(e) => {
+                      updateTagsPreview(e.currentTarget.value)
+                      void onChangeQuestion(e)
                     }}
-                  >
-                    <LightBulbIcon
-                      height={16}
-                      width={16}
-                      className="shrink-0"
+                    onKeyDown={onEnterSubmit}
+                    defaultValue={questionDefaults?.title}
+                    onMouseDown={(e) => e.stopPropagation()}
+                    {...registerQuestion}
+                    onFocus={() => setQuestionInFocus(true)}
+                    onBlur={() => setQuestionInFocus(false)}
+                    ref={mergeRefs([textAreaRef, formRef])}
+                  />
+                  <div className="flex flex-row items-center px-4 py-1 bg-neutral-200 gap-1">
+                    <TagsSelect
+                      tags={tagsPreview}
+                      setTags={setTagsPreview}
+                      customStyles={{
+                        valueContainer: (provided: any) => ({
+                          ...provided,
+                          backgroundColor: "white",
+                          borderRadius: "6px",
+                          fontSize: "14px",
+                          padding: "0",
+                          ":focus": {
+                            outline: "solid 2px #4338ca",
+                          },
+                          ":active": {
+                            outline: "solid 2px #4338ca",
+                          },
+                          ":focus-within": {
+                            outline: "solid 2px #4338ca",
+                          },
+                        }),
+                        control: (provided: any) => ({
+                          ...provided,
+                          border: "none",
+                          boxShadow: "none",
+                          padding: "0",
+                        }),
+                        input: (provided: any) => ({
+                          ...provided,
+                          margin: "0",
+                          padding: "0 5px",
+                          minHeight: "30px",
+                        }),
+                        placeholder: (provided: any) => ({
+                          ...provided,
+                          margin: "0",
+                          padding: "0 5px",
+                        }),
+                      }}
+                      containerWidth={containerRef.current?.offsetWidth}
                     />
-                  </button>
-                )}
+                    {showQuestionSuggestionsButton && (
+                      <button
+                        className={clsx(
+                          "inline-flex align-middle justify-center text-center btn btn-sm hover:opacity-100 min-h-8 text-neutral-500  bg-white hover:bg-white",
+                          showSuggestions
+                            ? "btn-active"
+                            : "hover:text-neutral-700",
+                          small && "btn-xs px-5",
+                        )}
+                        onClick={(e) => {
+                          setShowSuggestions(!showSuggestions)
+                          e.preventDefault()
+                        }}
+                      >
+                        Suggestions
+                      </button>
+                    )}
+                  </div>
+                </div>
               </div>
 
               <Transition

--- a/components/predict-form/Predict.tsx
+++ b/components/predict-form/Predict.tsx
@@ -410,11 +410,8 @@ export function Predict({
                       customStyles={{
                         valueContainer: (provided: any) => ({
                           ...provided,
-                          // backgroundColor: "white",
                           borderRadius: "6px",
                           fontSize: "14px",
-                          padding: "0",
-                          outline: "solid 2px transparent",
                           ":focus": {
                             outline: "solid 1px #4338ca",
                           },
@@ -444,7 +441,7 @@ export function Predict({
                           padding: "0 5px",
                         }),
                       }}
-                      containerWidth={containerRef.current?.offsetWidth}
+                      containerWidth={containerRef.current?.offsetWidth} // needed to set width of menu and number of columns
                     />
                     {showQuestionSuggestionsButton && (
                       <button

--- a/components/predict-form/Predict.tsx
+++ b/components/predict-form/Predict.tsx
@@ -1,5 +1,4 @@
 import { Transition } from "@headlessui/react"
-import { LightBulbIcon } from "@heroicons/react/24/solid"
 import { QuestionType } from "@prisma/client"
 import * as chrono from "chrono-node"
 import clsx from "clsx"

--- a/components/predict-form/Predict.tsx
+++ b/components/predict-form/Predict.tsx
@@ -122,6 +122,8 @@ export function Predict({
   })
 
   const [tagsPreview, setTagsPreview] = useState<string[]>([])
+  const [lastSubmittedTags, setLastSubmittedTags] = useState<string[]>([])
+
   const onSubmit: SubmitHandler<PredictFormType> = useCallback(
     (data, e) => {
       e?.preventDefault() // don't reload the page
@@ -208,6 +210,7 @@ export function Predict({
         )
       }
 
+      setLastSubmittedTags(tagsPreview)
       setTagsPreview([])
       reset()
       textAreaRef?.current?.focus()
@@ -350,7 +353,11 @@ export function Predict({
 
   // used to calculate width of TagsSelect menu
   const containerRef = useRef<HTMLDivElement>(null)
-  const purpleOutline = "solid 1px #4338ca"
+  const purpleOutline = "solid 2px #4338ca"
+
+  useEffect(() => {
+    setTagsPreview(lastSubmittedTags)
+  }, [lastSubmittedTags, resetTrigger])
 
   return (
     <div className="w-full">

--- a/components/predict-form/Predict.tsx
+++ b/components/predict-form/Predict.tsx
@@ -361,6 +361,7 @@ export function Predict({
 
   // used to calculate width of TagsSelect menu
   const containerRef = useRef<HTMLDivElement>(null);
+  const purpleOutline = "solid 1px #4338ca"
 
   return (
     <div className="w-full">
@@ -376,7 +377,9 @@ export function Predict({
 
                 <div
                   ref={containerRef}
-                  className={clsx("w-full rounded-md mb-2 relative z-20 border border-neutral-300 bg-neutral-100")}
+                  className={clsx(
+                    "w-full rounded-md mb-2 relative z-20 border border-neutral-300 bg-neutral-100",
+                  )}
                 >
                   <TextareaAutosize
                     className={clsx(
@@ -403,7 +406,7 @@ export function Predict({
                     onBlur={() => setQuestionInFocus(false)}
                     ref={mergeRefs([textAreaRef, formRef])}
                   />
-                  <div className="flex flex-row items-center px-4 py-2 gap-1 z-20">
+                  <div className="flex flex-row items-center p-2 sm:px-4 gap-1 z-20">
                     <TagsSelect
                       tags={tagsPreview}
                       setTags={setTagsPreview}
@@ -414,13 +417,13 @@ export function Predict({
                           fontSize: "14px",
                           minHeight: "38px", // needed to ensure the outline is in the correct
                           ":focus": {
-                            outline: "solid 1px #4338ca",
+                            outline: purpleOutline,
                           },
                           ":active": {
-                            outline: "solid 1px #4338ca",
+                            outline: purpleOutline,
                           },
                           ":focus-within": {
-                            outline: "solid 1px #4338ca",
+                            outline: purpleOutline,
                           },
                         }),
                         control: (provided: any) => ({

--- a/components/predict-form/Predict.tsx
+++ b/components/predict-form/Predict.tsx
@@ -377,13 +377,11 @@ export function Predict({
 
                 <div
                   ref={containerRef}
-                  className={clsx(
-                    "w-full border-2 border-neutral-300 rounded-md mb-2 bg-white shadow-lg relative z-20",
-                  )}
+                  className={clsx("w-full rounded-md mb-2 relative z-20 border border-neutral-300 bg-neutral-100")}
                 >
                   <TextareaAutosize
                     className={clsx(
-                      "w-full resize-none rounded-md p-4 -mb-2",
+                      "w-full resize-none rounded-md p-4 -mb-2 border-b bg-white shadow-lg ",
                       "focus:outline-indigo-700 placeholder:text-neutral-400",
                       small ? "text-md" : "text-xl",
                     )}
@@ -406,25 +404,26 @@ export function Predict({
                     onBlur={() => setQuestionInFocus(false)}
                     ref={mergeRefs([textAreaRef, formRef])}
                   />
-                  <div className="flex flex-row items-center px-4 py-1 bg-neutral-200 gap-1">
+                  <div className="flex flex-row items-center px-4 py-2 gap-1 z-20">
                     <TagsSelect
                       tags={tagsPreview}
                       setTags={setTagsPreview}
                       customStyles={{
                         valueContainer: (provided: any) => ({
                           ...provided,
-                          backgroundColor: "white",
+                          // backgroundColor: "white",
                           borderRadius: "6px",
                           fontSize: "14px",
                           padding: "0",
+                          outline: "solid 2px transparent",
                           ":focus": {
-                            outline: "solid 2px #4338ca",
+                            outline: "solid 1px #4338ca",
                           },
                           ":active": {
-                            outline: "solid 2px #4338ca",
+                            outline: "solid 1px #4338ca",
                           },
                           ":focus-within": {
-                            outline: "solid 2px #4338ca",
+                            outline: "solid 1px #4338ca",
                           },
                         }),
                         control: (provided: any) => ({
@@ -432,6 +431,7 @@ export function Predict({
                           border: "none",
                           boxShadow: "none",
                           padding: "0",
+                          minHeight: "30px", // otherwise container will expand to 38px and messes up background color
                         }),
                         input: (provided: any) => ({
                           ...provided,
@@ -450,9 +450,9 @@ export function Predict({
                     {showQuestionSuggestionsButton && (
                       <button
                         className={clsx(
-                          "inline-flex align-middle justify-center text-center btn btn-sm hover:opacity-100 min-h-8 text-neutral-500  bg-white hover:bg-white",
+                          "inline-flex align-middle justify-center text-center btn btn-sm hover:opacity-100 min-h-8 text-neutral-500 font-normal",
                           showSuggestions
-                            ? "btn-active"
+                            ? "btn-primary text-white"
                             : "hover:text-neutral-700",
                           small && "btn-xs px-5",
                         )}
@@ -492,11 +492,6 @@ export function Predict({
                 )}
               </Transition>
             </div>
-            {tagsPreview?.length > 0 && (
-              <div className="italic text-neutral-400 text-sm p-1 mb-2">
-                Tagging this question: {tagsPreview.join(", ")}
-              </div>
-            )}
 
             {(() => {
               switch (questionType) {

--- a/components/predict-form/Predict.tsx
+++ b/components/predict-form/Predict.tsx
@@ -348,19 +348,8 @@ export function Predict({
     ...registerQuestion
   } = register("question", { required: true })
 
-  function getTags(question: string) {
-    const tags = question.match(/#\w+/g)
-    return tags?.map((t) => t.replace("#", "")) || []
-  }
-  function updateTagsPreview(question: string) {
-    const tags = getTags(question)
-    if (tags.length > 0 || tagsPreview.length > 0) {
-      setTagsPreview(tags)
-    }
-  }
-
   // used to calculate width of TagsSelect menu
-  const containerRef = useRef<HTMLDivElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null)
   const purpleOutline = "solid 1px #4338ca"
 
   return (
@@ -378,12 +367,12 @@ export function Predict({
                 <div
                   ref={containerRef}
                   className={clsx(
-                    "w-full rounded-md mb-2 relative z-20 border border-neutral-300 bg-neutral-100",
+                    "w-full rounded-md mb-2 relative z-20 border-2 border-neutral-300 bg-neutral-100",
                   )}
                 >
                   <TextareaAutosize
                     className={clsx(
-                      "w-full resize-none rounded-md p-4 -mb-2 border-b bg-white",
+                      "w-full resize-none rounded-md p-4 -mb-2 border-b-2 bg-white box-border",
                       "focus:outline-indigo-700 placeholder:text-neutral-400",
                       small ? "text-md" : "text-xl",
                     )}
@@ -395,7 +384,6 @@ export function Predict({
                     }
                     maxRows={15}
                     onChange={(e) => {
-                      updateTagsPreview(e.currentTarget.value)
                       void onChangeQuestion(e)
                     }}
                     onKeyDown={onEnterSubmit}

--- a/components/predict-form/Predict.tsx
+++ b/components/predict-form/Predict.tsx
@@ -380,7 +380,7 @@ export function Predict({
                 >
                   <TextareaAutosize
                     className={clsx(
-                      "w-full resize-none rounded-md p-4 -mb-2 border-b bg-white shadow-lg ",
+                      "w-full resize-none rounded-md p-4 -mb-2 border-b bg-white",
                       "focus:outline-indigo-700 placeholder:text-neutral-400",
                       small ? "text-md" : "text-xl",
                     )}
@@ -412,6 +412,7 @@ export function Predict({
                           ...provided,
                           borderRadius: "6px",
                           fontSize: "14px",
+                          minHeight: "38px", // needed to ensure the outline is in the correct
                           ":focus": {
                             outline: "solid 1px #4338ca",
                           },
@@ -425,15 +426,14 @@ export function Predict({
                         control: (provided: any) => ({
                           ...provided,
                           border: "none",
+                          borderRadius: "8px",
                           boxShadow: "none",
                           padding: "0",
-                          minHeight: "30px", // otherwise container will expand to 38px and messes up background color
                         }),
                         input: (provided: any) => ({
                           ...provided,
                           margin: "0",
                           padding: "0 5px",
-                          minHeight: "30px",
                         }),
                         placeholder: (provided: any) => ({
                           ...provided,
@@ -446,7 +446,7 @@ export function Predict({
                     {showQuestionSuggestionsButton && (
                       <button
                         className={clsx(
-                          "inline-flex align-middle justify-center text-center btn btn-sm hover:opacity-100 min-h-8 text-neutral-500 font-normal",
+                          "inline-flex align-middle justify-center text-center btn btn-sm hover:opacity-100 min-h-[38px] text-neutral-500 font-normal",
                           showSuggestions
                             ? "btn-primary text-white"
                             : "hover:text-neutral-700",

--- a/components/questions/TagsSelect.tsx
+++ b/components/questions/TagsSelect.tsx
@@ -122,18 +122,24 @@ export function TagsSelect({
           }),
           menuList: (provided, state) => {
             // checks if there are <2 unselected options in the list
-            const remainingOptions = state.options.length - (Array.isArray(state.selectProps.value) ? state.selectProps.value.length : 0);
+            const remainingOptions =
+              state.options.length -
+              (Array.isArray(state.selectProps.value)
+                ? state.selectProps.value.length
+                : 0)
             return {
               ...provided,
               paddingTop: 0,
               paddingBottom: 0,
               display: "grid",
-              gridTemplateColumns: remainingOptions <= 1 ? "1fr" : "1fr 1fr",
+              gridTemplateColumns: containerWidth && containerWidth > 400 && remainingOptions > 1 ? "1fr 1fr" : "1fr",
               "@media (max-width: 768px)": {
                 gridTemplateColumns: "1fr",
               },
-              width: containerWidth ? `calc(${containerWidth}px - 2.25rem)` : provided.width, 
-            };
+              width: containerWidth
+                ? `calc(${containerWidth}px - 2.25rem)`
+                : provided.width,
+            }
           },
           multiValue: (provided) => ({
             ...provided,

--- a/components/questions/TagsSelect.tsx
+++ b/components/questions/TagsSelect.tsx
@@ -113,6 +113,7 @@ export function TagsSelect({
             primary: "#6366f1",
           },
         })}
+        // TODO: replace these with Tailwind classes in classNames above
         styles={{
           control: (provided, state) => ({
             ...provided,

--- a/components/questions/TagsSelect.tsx
+++ b/components/questions/TagsSelect.tsx
@@ -21,8 +21,8 @@ export function TagsSelect({
   disabled?: boolean
   placeholder?: string
   allowCreation?: boolean
-  customStyles?: any 
-  containerWidth?: number 
+  customStyles?: any
+  containerWidth?: number
 }) {
   const [localTags, setLocalTags] = useState<string[]>(tags)
   const allTagsQ = api.tags.getAll.useQuery()
@@ -132,13 +132,14 @@ export function TagsSelect({
               (Array.isArray(state.selectProps.value)
                 ? state.selectProps.value.length
                 : 0)
+            const inputValue = state.selectProps.inputValue
             return {
               ...provided,
               paddingTop: 0,
               paddingBottom: 0,
               display: "grid",
               gridTemplateColumns:
-                containerWidth && containerWidth > 400 && remainingOptions > 1
+                containerWidth && containerWidth > 400 && remainingOptions > 1 && !inputValue
                   ? "1fr 1fr"
                   : "1fr",
               [`@media (max-width: ${mobileBreakpoint}px)`]: {

--- a/components/questions/TagsSelect.tsx
+++ b/components/questions/TagsSelect.tsx
@@ -155,8 +155,10 @@ export function TagsSelect({
             backgroundColor: state.isFocused
               ? "#f5f5f5"
               : provided.backgroundColor,
+            borderRadius: state.isFocused ? "6px" : provided.borderRadius,
             ":hover": {
               backgroundColor: "#f5f5f5",
+              borderRadius: "6px",
             },
           }),
           valueContainer: (provided) => ({

--- a/components/questions/TagsSelect.tsx
+++ b/components/questions/TagsSelect.tsx
@@ -24,6 +24,7 @@ export function TagsSelect({
   const allTagsQ = api.tags.getAll.useQuery()
   const allTags = allTagsQ.data ?? []
 
+  // See https://react-select.com/styles for styling help
   // eslint-disable-next-line @typescript-eslint/naming-convention
   const SelectComponent = allowCreation ? CreatableSelect : Select
   return (
@@ -73,7 +74,9 @@ export function TagsSelect({
             <div className="flex items-center gap-1">
               <TagIcon className="text-neutral-400 w-4 h-4" />
               <span className="text-sm font-medium text-gray-700">
-                {option.label}
+                {context === "menu" && option.label.length > 20
+                  ? `${option.label.slice(0, 20)}...`
+                  : option.label}
               </span>
             </div>
             {context !== "value" && (
@@ -108,6 +111,60 @@ export function TagsSelect({
             ...provided,
             // 2px box shadow
             boxShadow: state.isFocused ? "0 0 0 2px #6366f1" : "none",
+          }),
+          menuList: (provided) => ({
+            ...provided,
+            paddingTop: 0,
+            paddingBottom: 0,
+            display: "grid",
+            gridTemplateColumns: "1fr 1fr",
+            "@media (max-width: 768px)": {
+              gridTemplateColumns: "1fr",
+            },
+          }),
+          multiValue: (provided) => ({
+            ...provided,
+            padding: "0rem",
+          }),
+          multiValueLabel: (provided, state) => ({
+            ...provided,
+            ":hover": {
+              borderRadius: "6px 0 0 6px",
+            },
+          }),
+          multiValueRemove: (provided, state) => ({
+            ...provided,
+            padding: "0.25rem",
+            borderRadius: "0 6px 6px 0",
+            backgroundColor: state.isFocused
+              ? "f5f5f5"
+              : provided.backgroundColor,
+            ":hover": {
+              backgroundColor: "#f5f5f5",
+              borderRadius: "0 6px 6px 0",
+              color: "black",
+            },
+          }),
+          option: (provided, state) => ({
+            ...provided,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            padding: "0.5rem",
+            wordBreak: "break-all",
+            backgroundColor: state.isFocused
+              ? "#f5f5f5"
+              : provided.backgroundColor,
+            ":hover": {
+              backgroundColor: "#f5f5f5",
+            },
+          }),
+          valueContainer: (provided) => ({
+            ...provided,
+            padding: "5px 0",
+            "@media (max-width: 768px)": {
+              padding: "5px 8px",
+            },
           }),
         }}
         noOptionsMessage={() =>

--- a/components/questions/TagsSelect.tsx
+++ b/components/questions/TagsSelect.tsx
@@ -13,12 +13,16 @@ export function TagsSelect({
   disabled,
   placeholder = "Add tags...",
   allowCreation = true,
+  customStyles = {},
+  containerWidth,
 }: {
   tags: string[]
   setTags: (tags: string[]) => void
   disabled?: boolean
   placeholder?: string
   allowCreation?: boolean
+  customStyles?: any 
+  containerWidth?: number 
 }) {
   const [localTags, setLocalTags] = useState<string[]>(tags)
   const allTagsQ = api.tags.getAll.useQuery()
@@ -28,7 +32,7 @@ export function TagsSelect({
   // eslint-disable-next-line @typescript-eslint/naming-convention
   const SelectComponent = allowCreation ? CreatableSelect : Select
   return (
-    <div className="">
+    <div className="flex-grow">
       <SelectComponent
         value={localTags.map((tag) => ({
           label: tag,
@@ -112,6 +116,10 @@ export function TagsSelect({
             // 2px box shadow
             boxShadow: state.isFocused ? "0 0 0 2px #6366f1" : "none",
           }),
+          menu: (provided) => ({
+            ...provided,
+            width: containerWidth ? `calc(${containerWidth}px - 2.25rem)` : provided.width,
+          }),
           menuList: (provided, state) => {
             // checks if there are <2 unselected options in the list
             const remainingOptions = state.options.length - (Array.isArray(state.selectProps.value) ? state.selectProps.value.length : 0);
@@ -124,6 +132,7 @@ export function TagsSelect({
               "@media (max-width: 768px)": {
                 gridTemplateColumns: "1fr",
               },
+              width: containerWidth ? `calc(${containerWidth}px - 2.25rem)` : provided.width, 
             };
           },
           multiValue: (provided) => ({
@@ -172,6 +181,7 @@ export function TagsSelect({
               padding: "5px 8px",
             },
           }),
+          ...customStyles,
         }}
         noOptionsMessage={() =>
           allowCreation

--- a/components/questions/TagsSelect.tsx
+++ b/components/questions/TagsSelect.tsx
@@ -126,7 +126,7 @@ export function TagsSelect({
             ...provided,
             padding: "0rem",
           }),
-          multiValueLabel: (provided, state) => ({
+          multiValueLabel: (provided) => ({
             ...provided,
             ":hover": {
               borderRadius: "6px 0 0 6px",

--- a/components/questions/TagsSelect.tsx
+++ b/components/questions/TagsSelect.tsx
@@ -27,6 +27,9 @@ export function TagsSelect({
   const [localTags, setLocalTags] = useState<string[]>(tags)
   const allTagsQ = api.tags.getAll.useQuery()
   const allTags = allTagsQ.data ?? []
+  const lightGrey = "#f5f5f5"
+  const mobileBreakpoint = 768
+  const borderRadius = "6px"
 
   // See https://react-select.com/styles for styling help
   // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -118,7 +121,9 @@ export function TagsSelect({
           }),
           menu: (provided) => ({
             ...provided,
-            width: containerWidth ? `calc(${containerWidth}px - 2.25rem)` : provided.width,
+            width: containerWidth
+              ? `calc(${containerWidth}px - 2.25rem)`
+              : provided.width,
           }),
           menuList: (provided, state) => {
             // checks if there are <2 unselected options in the list
@@ -132,8 +137,11 @@ export function TagsSelect({
               paddingTop: 0,
               paddingBottom: 0,
               display: "grid",
-              gridTemplateColumns: containerWidth && containerWidth > 400 && remainingOptions > 1 ? "1fr 1fr" : "1fr",
-              "@media (max-width: 768px)": {
+              gridTemplateColumns:
+                containerWidth && containerWidth > 400 && remainingOptions > 1
+                  ? "1fr 1fr"
+                  : "1fr",
+              [`@media (max-width: ${mobileBreakpoint}px)`]: {
                 gridTemplateColumns: "1fr",
               },
               width: containerWidth
@@ -148,19 +156,18 @@ export function TagsSelect({
           multiValueLabel: (provided) => ({
             ...provided,
             ":hover": {
-              borderRadius: "6px 0 0 6px",
+              borderRadius: `${borderRadius} 0 0 ${borderRadius}`,
             },
           }),
           multiValueRemove: (provided, state) => ({
             ...provided,
             padding: "0.25rem",
-            borderRadius: "0 6px 6px 0",
+            borderRadius: `0 ${borderRadius} ${borderRadius} 0`,
             backgroundColor: state.isFocused
               ? "f5f5f5"
               : provided.backgroundColor,
             ":hover": {
-              backgroundColor: "#f5f5f5",
-              borderRadius: "0 6px 6px 0",
+              backgroundColor: lightGrey,
               color: "black",
             },
           }),
@@ -172,18 +179,20 @@ export function TagsSelect({
             padding: "0.5rem",
             wordBreak: "break-all",
             backgroundColor: state.isFocused
-              ? "#f5f5f5"
+              ? lightGrey
               : provided.backgroundColor,
-            borderRadius: state.isFocused ? "6px" : provided.borderRadius,
+            borderRadius: state.isFocused
+              ? borderRadius
+              : provided.borderRadius,
             ":hover": {
-              backgroundColor: "#f5f5f5",
-              borderRadius: "6px",
+              backgroundColor: lightGrey,
+              borderRadius: borderRadius,
             },
           }),
           valueContainer: (provided) => ({
             ...provided,
             padding: "5px 0",
-            "@media (max-width: 768px)": {
+            [`@media (max-width: ${mobileBreakpoint}px)`]: {
               padding: "5px 8px",
             },
           }),

--- a/components/questions/TagsSelect.tsx
+++ b/components/questions/TagsSelect.tsx
@@ -112,16 +112,20 @@ export function TagsSelect({
             // 2px box shadow
             boxShadow: state.isFocused ? "0 0 0 2px #6366f1" : "none",
           }),
-          menuList: (provided) => ({
-            ...provided,
-            paddingTop: 0,
-            paddingBottom: 0,
-            display: "grid",
-            gridTemplateColumns: "1fr 1fr",
-            "@media (max-width: 768px)": {
-              gridTemplateColumns: "1fr",
-            },
-          }),
+          menuList: (provided, state) => {
+            // checks if there are <2 unselected options in the list
+            const remainingOptions = state.options.length - (Array.isArray(state.selectProps.value) ? state.selectProps.value.length : 0);
+            return {
+              ...provided,
+              paddingTop: 0,
+              paddingBottom: 0,
+              display: "grid",
+              gridTemplateColumns: remainingOptions <= 1 ? "1fr" : "1fr 1fr",
+              "@media (max-width: 768px)": {
+                gridTemplateColumns: "1fr",
+              },
+            };
+          },
           multiValue: (provided) => ({
             ...provided,
             padding: "0rem",


### PR DESCRIPTION
# Pull Request: Adds TagsSelect to Predict component

## Related Issue
[Asana ref](https://app.asana.com/0/1208202570969977/1208330467427716/f)

## Changes Made
- Added TagsSelect component to Predict component
- Added custom styles prop for TagsSelect component
- Updated styling of inner components for TagsSelect component
- Updated questionSuggestionsButton to have "Suggestions" label rather than use lightbulb icon

## Testing
Tested locally and in preview, for TagsSelect components in Predict, Question and Calibration components.

