### PR TITLE
Stops filters overflowing their container at certain resolutions

### DIFF
--- a/components/FilterControls.tsx
+++ b/components/FilterControls.tsx
@@ -86,7 +86,7 @@ export function FilterControls({
           unresolved: !extraFilters.resolvingSoon,
         }),
       filterActive: extraFilters.resolvingSoon,
-      className: "@xl:block",
+      className: "hidden",
       overflowClassName: "",
     },
     {
@@ -99,7 +99,7 @@ export function FilterControls({
           readyToResolve: !extraFilters.readyToResolve,
         }),
       filterActive: extraFilters.readyToResolve,
-      className: "@sm:block",
+      className: "@xs:hidden @md:block",
       overflowClassName: "@sm:hidden",
     },
     {
@@ -126,7 +126,7 @@ export function FilterControls({
           resolved: false,
         }),
       filterActive: extraFilters.unresolved,
-      className: "@xl:block",
+      className: "hidden",
       overflowClassName: "",
     },
   ]

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -42,7 +42,7 @@ function Sidebar() {
 
   // NB: hidden on mobile, stats.tsx is shown instead
   return (
-    <div className="max-sm:hidden flex flex-col gap-12 max-w-[400px]">
+    <div className="max-md:hidden flex flex-col gap-12 max-w-[400px]">
       <div className="min-h-28">{userId && <OnboardingChecklist />}</div>
       <div className="max-w-[320px] flex flex-col gap-12 ml-auto lg:w-[320px]">
         {userId && <TrackRecord trackRecordUserId={userId} />}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -15,7 +15,7 @@ export default function HomePage() {
   const userId = useUserId()
 
   return (
-    <div className="max-sm:flex-col gap-8 lg:gap-12 flex justify-center px-4 lg:pt-4 mx-auto max-w-6xl">
+    <div className="max-md:flex-col gap-8 lg:gap-12 flex justify-center px-4 lg:pt-4 mx-auto max-w-6xl">
       <PredictProvider>
         <div className="prose mx-auto pt-12 lg:w-[650px]">
           {!userId && sessionStatus !== "loading" && (


### PR DESCRIPTION
# Pull Request: Stops filters overflowing their container at certain resolutions

## Related Issue
[Asana ref](https://app.asana.com/0/1208202570969977/1208253633969381/f)

## Changes Made
- Changes the breakpoint for when the 2 column index page layout becomes a single column to a wider resolution
- Changes which filter buttons are displayed at which breakpoints (the whole filter component could use overhauling but that would need prioritising as its own ticket)

## Testing
Tested in local and preview on FF and Chrome, using dev tools Responsive Design Mode
