### PR TITLE
Changes column breakpoint for question information to be lg

### DIFF
--- a/components/questions/Question.tsx
+++ b/components/questions/Question.tsx
@@ -153,7 +153,7 @@ export function Question({
                 ))}
               </div>
             )}
-            <div className="grid grid-cols-2 md:grid-cols-4 gap-2 col-span-3">
+            <div className="grid grid-cols-2 lg:grid-cols-4 gap-2 col-span-3">
               <span className="text-sm my-auto" key={`${question.id}author`}>
                 <Username user={question.user} unknownUserText="Anonymous" />
               </span>


### PR DESCRIPTION
# Pull Request: Changes column breakpoint for question information to be lg

## Related Issue
[Asana ref](https://app.asana.com/0/1208202570969977/1208364934071399/f)

## Changes Made
- Changes breakpoint from `md` -> `lg` for the columnar layout in Question.tsx

## Testing
Tested locally and in preview. At some resolutions the question component now looks a bit stretched, but IMO this is preferable to having overlapping elements at other resolutions.

Before/after at 790px (only showing left column):
<img width="439" alt="Screenshot 2024-09-25 at 13 02 52" src="https://github.com/user-attachments/assets/deb9549f-d79e-4029-8487-8b37a7e84118">
<img width="345" alt="Screenshot 2024-09-25 at 13 03 21" src="https://github.com/user-attachments/assets/a6305845-47e9-45a8-aec4-2a1ccf91323d">

