### PR TITLE
Reduces TagsSelect menuList component to always have single column layout, removes tag name truncation

### DIFF
--- a/components/predict-form/Predict.tsx
+++ b/components/predict-form/Predict.tsx
@@ -439,7 +439,7 @@ export function Predict({
                           padding: "0 5px",
                         }),
                       }}
-                      containerWidth={containerRef.current?.offsetWidth} // needed to set width of menu and number of columns
+                      containerWidth={containerRef.current?.offsetWidth} // needed to set width of menu
                     />
                     {showQuestionSuggestionsButton && (
                       <button

--- a/components/questions/TagsSelect.tsx
+++ b/components/questions/TagsSelect.tsx
@@ -129,7 +129,7 @@ export function TagsSelect({
         styles={{
           multiValue: (provided) => ({
             ...provided,
-            maxWidth: "190px",
+            maxWidth: "100%",
           }),
           multiValueLabel: (provided) => ({
             ...provided,

--- a/components/questions/TagsSelect.tsx
+++ b/components/questions/TagsSelect.tsx
@@ -81,9 +81,7 @@ export function TagsSelect({
             <div className="flex items-center gap-1">
               <TagIcon className="text-neutral-400 w-4 h-4" />
               <span className="text-sm font-medium text-gray-700">
-                {context === "menu" && option.label.length > 20
-                  ? `${option.label.slice(0, 20)}...`
-                  : option.label}
+                {option.label}
               </span>
             </div>
             {context !== "value" && (
@@ -139,13 +137,7 @@ export function TagsSelect({
               paddingTop: 0,
               paddingBottom: 0,
               display: "grid",
-              gridTemplateColumns:
-                containerWidth && containerWidth > 400 && remainingOptions > 1 && !inputValue
-                  ? "1fr 1fr"
-                  : "1fr",
-              [`@media (max-width: ${mobileBreakpoint}px)`]: {
-                gridTemplateColumns: "1fr",
-              },
+              gridTemplateColumns: "1fr",
               width: containerWidth
                 ? `calc(${containerWidth}px - 2.25rem)`
                 : provided.width,

--- a/components/questions/TagsSelect.tsx
+++ b/components/questions/TagsSelect.tsx
@@ -28,8 +28,6 @@ export function TagsSelect({
   const allTagsQ = api.tags.getAll.useQuery()
   const allTags = allTagsQ.data ?? []
   const lightGrey = "#f5f5f5"
-  const mobileBreakpoint = 768
-  const borderRadius = "6px"
 
   // See https://react-select.com/styles for styling help
   // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -93,15 +91,30 @@ export function TagsSelect({
         )}
         className="cursor-text"
         classNames={{
-          control: () =>
+          control: ({ isFocused }) =>
             clsx(
-              "!border-none shadow-inner !cursor-text md:px-2",
+              "!border-none shadow-inner !cursor-text md:px-2 !rounded-md",
               allowCreation ? "!bg-neutral-200" : "!bg-neutral-100",
+              isFocused ? "!shadow-[0_0_0_2px_#6366f1]" : "!shadow-none",
             ),
+          menuList: () =>
+            containerWidth
+              ? `!w-[calc(${containerWidth}px-2.25rem)] !py-0`
+              : "!py-0",
           multiValue: () =>
-            "!bg-white shadow-sm px-0.5 !rounded-md !cursor-pointer not-prose",
-          multiValueLabel: () => "hover:underline hover:bg-neutral-100",
-          multiValueRemove: () => "text-neutral-400 !px-0.5",
+            "!bg-white shadow-sm px-0.5 !rounded-md !cursor-pointer not-prose !p-0",
+          multiValueLabel: () =>
+            "hover:underline hover:bg-neutral-100 hyphenated break-words hover:rounded-s-md",
+          multiValueRemove: () => "text-neutral-400 !px-0.5 !rounded-e-md",
+          menu: () =>
+            containerWidth ? `!w-[calc(${containerWidth}px-2.25rem)]` : "",
+          option: ({ isFocused }) =>
+            clsx(
+              "flex items-center justify-center p-2 break-all",
+              isFocused ? "!bg-[#f5f5f5] !rounded-md" : "",
+              "hover:bg-[#f5f5f5] hover:rounded-md",
+            ),
+          valueContainer: () => "!py-[5px] !md:px-0 !px-2",
         }}
         theme={(theme) => ({
           ...theme,
@@ -113,81 +126,14 @@ export function TagsSelect({
         })}
         // TODO: replace these with Tailwind classes in classNames above
         styles={{
-          control: (provided, state) => ({
-            ...provided,
-            // 2px box shadow
-            boxShadow: state.isFocused ? "0 0 0 2px #6366f1" : "none",
-          }),
-          menu: (provided) => ({
-            ...provided,
-            width: containerWidth
-              ? `calc(${containerWidth}px - 2.25rem)`
-              : provided.width,
-          }),
-          menuList: (provided, state) => {
-            // checks if there are <2 unselected options in the list
-            const remainingOptions =
-              state.options.length -
-              (Array.isArray(state.selectProps.value)
-                ? state.selectProps.value.length
-                : 0)
-            const inputValue = state.selectProps.inputValue
-            return {
-              ...provided,
-              paddingTop: 0,
-              paddingBottom: 0,
-              display: "grid",
-              gridTemplateColumns: "1fr",
-              width: containerWidth
-                ? `calc(${containerWidth}px - 2.25rem)`
-                : provided.width,
-            }
-          },
-          multiValue: (provided) => ({
-            ...provided,
-            padding: "0rem",
-          }),
-          multiValueLabel: (provided) => ({
-            ...provided,
-            ":hover": {
-              borderRadius: `${borderRadius} 0 0 ${borderRadius}`,
-            },
-          }),
           multiValueRemove: (provided, state) => ({
             ...provided,
-            padding: "0.25rem",
-            borderRadius: `0 ${borderRadius} ${borderRadius} 0`,
             backgroundColor: state.isFocused
               ? "f5f5f5"
               : provided.backgroundColor,
             ":hover": {
               backgroundColor: lightGrey,
               color: "black",
-            },
-          }),
-          option: (provided, state) => ({
-            ...provided,
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            padding: "0.5rem",
-            wordBreak: "break-all",
-            backgroundColor: state.isFocused
-              ? lightGrey
-              : provided.backgroundColor,
-            borderRadius: state.isFocused
-              ? borderRadius
-              : provided.borderRadius,
-            ":hover": {
-              backgroundColor: lightGrey,
-              borderRadius: borderRadius,
-            },
-          }),
-          valueContainer: (provided) => ({
-            ...provided,
-            padding: "5px 0",
-            [`@media (max-width: ${mobileBreakpoint}px)`]: {
-              padding: "5px 8px",
             },
           }),
           ...customStyles,

--- a/components/questions/TagsSelect.tsx
+++ b/components/questions/TagsSelect.tsx
@@ -127,11 +127,11 @@ export function TagsSelect({
         // TODO: replace these with Tailwind classes in classNames above
         // Sometimes the class don't get applied while the styles do :(
         styles={{
-          multiValue: (provided, state) => ({
+          multiValue: (provided) => ({
             ...provided,
             maxWidth: "190px",
           }),
-          multiValueLabel: (provided, state) => ({
+          multiValueLabel: (provided) => ({
             ...provided,
             wordBreak: "break-all",
             textWrap: "wrap",

--- a/components/questions/TagsSelect.tsx
+++ b/components/questions/TagsSelect.tsx
@@ -77,7 +77,7 @@ export function TagsSelect({
         ) => (
           <div className="flex items-center justify-between w-full">
             <div className="flex items-center gap-1">
-              <TagIcon className="text-neutral-400 w-4 h-4" />
+              <TagIcon className="text-neutral-400 w-4 h-4 min-w-4" />
               <span className="text-sm font-medium text-gray-700">
                 {option.label}
               </span>
@@ -104,7 +104,7 @@ export function TagsSelect({
           multiValue: () =>
             "!bg-white shadow-sm px-0.5 !rounded-md !cursor-pointer not-prose !p-0",
           multiValueLabel: () =>
-            "hover:underline hover:bg-neutral-100 hyphenated break-words hover:rounded-s-md",
+            "hover:underline hover:bg-neutral-100 hyphenated break-all hover:rounded-s-md",
           multiValueRemove: () => "text-neutral-400 !px-0.5 !rounded-e-md",
           menu: () =>
             containerWidth ? `!w-[calc(${containerWidth}px-2.25rem)]` : "",
@@ -125,7 +125,17 @@ export function TagsSelect({
           },
         })}
         // TODO: replace these with Tailwind classes in classNames above
+        // Sometimes the class don't get applied while the styles do :(
         styles={{
+          multiValue: (provided, state) => ({
+            ...provided,
+            maxWidth: "190px",
+          }),
+          multiValueLabel: (provided, state) => ({
+            ...provided,
+            wordBreak: "break-all",
+            textWrap: "wrap",
+          }),
           multiValueRemove: (provided, state) => ({
             ...provided,
             backgroundColor: state.isFocused


### PR DESCRIPTION
# Pull Request: Reduces TagsSelect menuList component to always have single column layout, removes tag name truncation

## Changes Made
- Sets the menuList to only have a single column, by removing grid layout entirely
- Removes tag name truncation
- Sets max-width on the tag label to stop long tags expanding their container
- Partially replaces the raw CSS in the TagsSelect component with Tailwind classes

## Testing
Tested locally and in preview

<img width="389" alt="Screenshot 2024-09-25 at 16 16 43" src="https://github.com/user-attachments/assets/9c3758df-f7dc-4f1b-8e03-7cde9385cfef">
<img width="389" alt="Screenshot 2024-09-25 at 16 16 54" src="https://github.com/user-attachments/assets/ca220bdf-8ae1-45ea-b0a1-76ac0307091f">

