### PR TITLE
Removes border radius from transparent input in UpdateableLatestForecast

### DIFF
--- a/components/questions/UpdateableLatestForecast.tsx
+++ b/components/questions/UpdateableLatestForecast.tsx
@@ -200,7 +200,7 @@ export function UpdateableLatestForecast({
               enterKeyHint="go"
               pattern="[0-9]*"
               className={
-                "pl-1 w-16 text-right rounded-md focus:outline-none bg-transparent"
+                "pl-1 w-16 text-right focus:outline-none bg-transparent"
               }
               value={localForecast}
               placeholder="__"


### PR DESCRIPTION
# Pull Request: Removes border radius from transparent input in UpdateableLatestForecast

## Related Issue
[Asana ref](https://app.asana.com/0/1208202570969977/1208364934071391/f)

## Changes Made
- Removes `rounded-md` from transparent input element in UpdateableLatestForecast component

## Testing
Tested locally and in preview
Before/after:
<img width="112" alt="Screenshot 2024-09-25 at 16 49 42" src="https://github.com/user-attachments/assets/cf6bd016-539d-4ab9-a6e6-b66b7675bd7c">
<img width="115" alt="Screenshot 2024-09-25 at 16 49 51" src="https://github.com/user-attachments/assets/378e3c22-5e07-4676-8961-0afca6d3baa0">
