### PR TITLE
Remove break-all class from comment display

### DIFF
--- a/components/questions/QuestionDetails.tsx
+++ b/components/questions/QuestionDetails.tsx
@@ -177,7 +177,7 @@ function EventsLog({ question }: { question: QuestionWithStandardIncludes }) {
               <FormattedDate date={c.createdAt} className="my-auto" />
               <DeleteCommentOverflow question={question} comment={c} />
             </span>
-            <span className="md:pl-7 col-span-4 -mt-1 break-all min-w-0 whitespace-pre-line">
+            <span className="md:pl-7 col-span-4 -mt-1 min-w-0 whitespace-pre-line">
               {c.comment}
             </span>
           </Fragment>


### PR DESCRIPTION
Currently words in the comment rendering are arbitrarily broken, this removes this behavior making words wrap at the end of the line instead

# Pull Request: Remove break-all class from comment display

Before:
![image](https://github.com/user-attachments/assets/c64454ea-eafa-4ed7-b61b-b0fb3bbf1b08)

After:
![image](https://github.com/user-attachments/assets/ddd9fdd2-9a72-45ea-908c-1644bd1db9d3)
