### PR TITLE
Fix: Always use english localization when running jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "iOS": "npx next build && npx next export && npx cap sync ios && npx cap run ios",
     "zip": "echo \"have you set isDev=false and incremented version num?\" && bash zip-extensions.sh",
     "prepare": "husky install",
-    "test": "jest"
+    "test": "LC_ALL=en-US jest"
   },
   "dependencies": {
     "@capacitor/android": "^6.1.0",


### PR DESCRIPTION
# Pull Request: Always use english localization when running jest

## Related Issue

Running tests uses your local machines localization settings, which was causing them to fail for me.

## Changes Made

- Set to en-US before running tests

## Testing

See this Loom ([here](https://www.loom.com/share/67a528c01e39444ab1015942ed500e97))