### PR TITLE
Add tag-specific calibration chart to tag page

### DIFF
--- a/pages/tag/[tag].tsx
+++ b/pages/tag/[tag].tsx
@@ -31,17 +31,15 @@ export default function TagPage() {
             </>
           )}
           {tagQ.data ? (
-            <>
-              <Questions
-                title={
-                  tagQ.data?.name
-                    ? `Your “${tagQ.data.name}” questions`
-                    : "Loading..."
-                }
-                filterTagIds={[tagQ.data.id]}
-                noQuestionsText="No questions tagged with this tag yet."
-              />
-            </>
+            <Questions
+              title={
+                tagQ.data?.name
+                  ? `Your “${tagQ.data.name}” questions`
+                  : "Loading..."
+              }
+              filterTagIds={[tagQ.data.id]}
+              noQuestionsText="No questions tagged with this tag yet."
+            />
           ) : (
             <h3 className="text-neutral-600">
               {tagQ.isLoading ? "Loading..." : ""}

--- a/pages/tag/[tag].tsx
+++ b/pages/tag/[tag].tsx
@@ -3,6 +3,7 @@ import { useRouter } from "next/router"
 import { Questions } from "../../components/Questions"
 import { api, getClientBaseUrl } from "../../lib/web/trpc"
 import { useUserId } from "../../lib/web/utils"
+import { CalibrationChart } from "../../components/CalibrationChart"
 
 export function getTagPageUrl(tagName: string, useRelativePath?: boolean) {
   return `${getClientBaseUrl(useRelativePath)}/tag/${encodeURIComponent(
@@ -22,7 +23,7 @@ export default function TagPage() {
   return (
     <div className="px-4 pt-12 lg:pt-16 mx-auto max-w-6xl">
       <NextSeo title={tagQ.data?.name} noindex={true} nofollow={true} />
-      <div className="mx-auto">
+      <div className="max-md:flex-col gap-8 lg:gap-12 flex justify-center px-4 lg:pt-4 mx-auto max-w-6xl">
         <div className="prose mx-auto lg:w-[650px]">
           {!userId && (
             <>
@@ -30,21 +31,27 @@ export default function TagPage() {
             </>
           )}
           {tagQ.data ? (
-            <Questions
-              title={
-                tagQ.data?.name
-                  ? `Your “${tagQ.data.name}” questions`
-                  : "Loading..."
-              }
-              filterTagIds={[tagQ.data.id]}
-              noQuestionsText="No questions tagged with this tag yet."
-            />
+            <>
+              <Questions
+                title={
+                  tagQ.data?.name
+                    ? `Your “${tagQ.data.name}” questions`
+                    : "Loading..."
+                }
+                filterTagIds={[tagQ.data.id]}
+                noQuestionsText="No questions tagged with this tag yet."
+              />
+            </>
           ) : (
             <h3 className="text-neutral-600">
               {tagQ.isLoading ? "Loading..." : ""}
             </h3>
           )}
         </div>
+        {tagQ.data && userId && <div className="prose max-md:hidden flex flex-col gap-12 max-w-[400px]">
+          <h3 className="pt-6 pb-4">Your calibration on “{tagQ.data.name}” questions</h3>
+          <CalibrationChart userId={userId} tags={[tagName]} />
+        </div>}
       </div>
     </div>
   )


### PR DESCRIPTION
# Pull Request: Add tag-specific calibration chart to tag page

## Changes Made

When I'm interested in my calibration for a specific tag, the first place I thought to look was on the page for that tag. Since it wasn't there, I thought I'd add it.

<img width="1196" alt="calibration on tag page" src="https://github.com/user-attachments/assets/93afd586-8787-4047-90a8-21d4ac66fa19" />

## Testing

Manually looked at the tag page, resolved questions with that tag, and observed the results on the graph
