### PR TITLE
Pages: API setup: mention time localization workaround

### DIFF
--- a/pages/api-setup.tsx
+++ b/pages/api-setup.tsx
@@ -113,7 +113,7 @@ export default function ApiPage() {
           <br />
         </p>
 
-        <p>{"Note a date by itself will default to a time of 00:00 in the UTC timezone, which may not be the date you intended in your local timezone.  You can pass an ISO 8601 datetime for localization; for example, 2025-01-01T00:00+00:00.  You can also add some optional parameters, here's an example:"}</p>
+        <p>{"Note: a date by itself will default to a time of 00:00 in the UTC timezone, which may not be the date you intended in your local timezone.  You can pass an ISO 8601 datetime for localization; for example, 2025-01-01T00:00+00:00.  You can also add some optional parameters, here's an example:"}</p>
 
         <p className="bg-neutral-100 outline outline-neutral-300 outline-1 p-2 rounded-md break-words">
           {"https://fatebook.io/api/v0/createQuestion"}

--- a/pages/api-setup.tsx
+++ b/pages/api-setup.tsx
@@ -113,7 +113,7 @@ export default function ApiPage() {
           <br />
         </p>
 
-        <p>{"You can also add some optional parameters, here's an example:"}</p>
+        <p>{"Note a date by itself will default to a time of 00:00 in the UTC timezone, which may not be the date you intended in your local timezone.  You can pass an ISO 8601 datetime for localization; for example, 2025-01-01T00:00+00:00.  You can also add some optional parameters, here's an example:"}</p>
 
         <p className="bg-neutral-100 outline outline-neutral-300 outline-1 p-2 rounded-md break-words">
           {"https://fatebook.io/api/v0/createQuestion"}


### PR DESCRIPTION
Adds two sentences to the API setup page to describe a workaround to an issue I encountered.

When using the API in the UTC-10:00 timezone, all of my questions for "tomorrow" were showing in the web interface as "resolves today".  Passing an ISO 8601 date localized to my timezone seems to fix the issue, so I made some guesses about how the system worked and added some descriptive text to help other devs hopefully avoid the issue.

Not tested.