### PR TITLE
Plot calibration chart at mean predictions instead of bin ends

### DIFF
--- a/components/CalibrationChart.tsx
+++ b/components/CalibrationChart.tsx
@@ -50,9 +50,8 @@ export function CalibrationChart({
 
   if (!bucketedForecastsQ.data) return <div className="min-h-[331px]"></div>
 
-  const { buckets, bucketedForecasts } = bucketedForecastsQ.data
+  const { bucketedForecasts } = bucketedForecastsQ.data
   const params = getChartJsParams(
-    buckets,
     bucketedForecasts,
     true,
     !axisTitlesShown,
@@ -88,15 +87,17 @@ export function CalibrationChart({
         onClick={(event) => {
           chartRef.current &&
             getElementAtEvent(chartRef.current, event)?.forEach((element) => {
-              const midpoint = element.index * 10 // e.g. "70"
-              const range = [
-                Math.max(0, midpoint - 5),
-                Math.min(100, midpoint + 5),
-              ]
-              const searchString = `${range[0]}-${range[1]}%`
-              window.dispatchEvent(
-                new CustomEvent("setSearchString", { detail: searchString }),
-              )
+              const clickedBucket = bucketedForecasts[element.index]
+              if (clickedBucket) {
+                // Calculate bin boundaries (10% wide bins)
+                const binWidth = 10
+                const binIndex = element.index
+                const range = [binIndex * binWidth, (binIndex + 1) * binWidth]
+                const searchString = `${range[0]}-${range[1]}%`
+                window.dispatchEvent(
+                  new CustomEvent("setSearchString", { detail: searchString }),
+                )
+              }
             })
         }}
       />

--- a/lib/web/utils.ts
+++ b/lib/web/utils.ts
@@ -27,22 +27,38 @@ export async function signInToFatebook() {
 }
 
 export function getChartJsParams(
-  buckets: number[],
-  bucketedForecasts: { bucket: number; mean: number; count: number }[],
+  bucketedForecasts: {
+    binCenter: number
+    meanPrediction: number
+    meanOutcome: number
+    count: number
+  }[],
   interactive = false,
   hideTitles = false,
   isThisUser = true,
 ) {
   const pronoun = isThisUser ? "Your" : "Their"
+
+  // Perfect calibration line: diagonal y=x from 0% to 100%
+  const perfectCalibrationData = [
+    { x: 0, y: 0 },
+    { x: 100, y: 100 },
+  ]
+
+  // User calibration: plot at actual mean prediction (not bin center)
+  const userCalibrationData = bucketedForecasts.map((f) => ({
+    x: f.meanPrediction * 100,
+    y: isNaN(f.meanOutcome) ? null : f.meanOutcome * 100,
+  }))
+
   return {
     type: "line",
     data: {
-      labels: buckets.map((b) => (b * 100).toFixed(0) + "%"),
       datasets: [
         {
           backgroundColor: "#4e46e59c",
           borderColor: "#4e46e59c",
-          data: bucketedForecasts.map((f) => f.mean * 100),
+          data: userCalibrationData,
           label: `${pronoun} calibration`,
           borderWidth: 1,
           fill: false,
@@ -51,7 +67,7 @@ export function getChartJsParams(
         {
           backgroundColor: "#22c55e",
           borderColor: "#22c55e",
-          data: [0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100],
+          data: perfectCalibrationData,
           label: "Perfect calibration",
           fill: false,
           pointRadius: 0,
@@ -71,20 +87,23 @@ export function getChartJsParams(
         ? {
             tooltip: {
               callbacks: {
+                title: () => null,
                 label: (context: any) => {
-                  const label = context.dataset.label || ""
-                  if (label) {
-                    const resolvedForecasts =
-                      bucketedForecasts?.[context?.dataIndex]?.count
+                  const datasetLabel = context.dataset.label || ""
 
-                    return `${label}: ${context.parsed.y.toFixed(0)}%${
-                      resolvedForecasts !== undefined &&
-                      ` (on ${resolvedForecasts} forecast${
-                        resolvedForecasts > 1 ? "s" : ""
-                      })`
-                    }`
+                  // Skip tooltip for perfect calibration line
+                  if (datasetLabel.includes("Perfect")) {
+                    return null
                   }
-                  return ""
+
+                  const bucket = bucketedForecasts?.[context?.dataIndex]
+                  if (!bucket) return ""
+
+                  const n = bucket.count
+                  const pred = (bucket.meanPrediction * 100).toFixed(1)
+                  const outcome = (bucket.meanOutcome * 100).toFixed(1)
+
+                  return [`n=${n}`, `${pred}% pred`, `${outcome}% outcome`]
                 },
               },
             },
@@ -117,10 +136,17 @@ export function getChartJsParams(
               },
             },
             x: {
+              type: "linear",
+              min: 0,
+              max: 100,
               title: {
                 display: true,
-                text: `${pronoun} forecast (bucketed by nearest 10%)`,
+                text: `${pronoun} forecast`,
                 color: hideTitles ? "transparent" : "gray",
+              },
+              ticks: {
+                stepSize: 10,
+                callback: (value: any) => value + "%",
               },
             },
           }
@@ -128,9 +154,15 @@ export function getChartJsParams(
             xAxes: [
               {
                 display: true,
+                type: "linear",
+                ticks: {
+                  min: 0,
+                  max: 100,
+                  callback: (value: any) => value + "%",
+                },
                 scaleLabel: {
                   display: true,
-                  labelString: `${pronoun} forecast (bucketed by nearest 10%)`,
+                  labelString: `${pronoun} forecast`,
                 },
                 gridLines: {
                   color: "#1e1e1e",

--- a/pages/api/calibration_graph.ts
+++ b/pages/api/calibration_graph.ts
@@ -19,12 +19,12 @@ export default async function handler(
     res.send("No results")
     return
   }
-  const { buckets, bucketedForecasts } = results
+  const { bucketedForecasts } = results
 
   const chartJs = new ChartJSImage()
   const lineChart = chartJs
     //@ts-ignore - the library's type definition is incorrect
-    .chart(getChartJsParams(buckets, bucketedForecasts))
+    .chart(getChartJsParams(bucketedForecasts))
     .backgroundColor("#111")
     .width("550")
     .height("500")
@@ -166,26 +166,45 @@ export async function getBucketedForecasts(userId: string, tags?: string[]) {
 
   forecasts.push(...mcqForecasts)
 
-  const halfBucketSize = 0.05
-  const buckets = [0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1]
-  const bucketedForecasts = buckets.map((bucket) => {
-    const forecastsInBucket = forecasts.filter((f) => {
-      return (
-        f.forecast >= bucket - halfBucketSize &&
-        // without this fudge, 0.85 is included in the 0.8 and 0.9 buckets
-        f.forecast < bucket + halfBucketSize - 0.00000001
-      )
-    })
+  // Create 10 equal-width bins: [0-10%), [10-20%), ..., [90-100%]
+  const NUM_BINS = 10
+  const BIN_WIDTH = 1.0 / NUM_BINS
+
+  // Guarantees each forecast goes to exactly one bin
+  function getBinIndex(value: number): number {
+    if (value >= 1.0) return NUM_BINS - 1
+    return Math.floor(value * NUM_BINS)
+  }
+
+  const bins: typeof forecasts[] = Array.from({ length: NUM_BINS }, () => [])
+  forecasts.forEach((f) => {
+    bins[getBinIndex(f.forecast)].push(f)
+  })
+
+  const bucketedForecasts = bins.map((forecastsInBin, i) => {
+    const binStart = i * BIN_WIDTH
+    const binEnd = (i + 1) * BIN_WIDTH
+    const binCenter = (binStart + binEnd) / 2
+
+    const count = forecastsInBin.length
+    const meanPrediction =
+      count > 0
+        ? forecastsInBin.reduce((sum, f) => sum + f.forecast, 0) / count
+        : binCenter
+
+    const meanOutcome =
+      count > 0
+        ? forecastsInBin.filter((f) => f.resolution === Resolution.YES).length /
+          count
+        : NaN
 
     return {
-      bucket: bucket,
-      mean:
-        forecastsInBucket.reduce(
-          (acc, f) => acc + (f.resolution === Resolution.YES ? 1 : 0),
-          0,
-        ) / forecastsInBucket.length,
-      count: forecastsInBucket.length,
+      binCenter,
+      meanPrediction,
+      meanOutcome,
+      count,
     }
   })
-  return { buckets, bucketedForecasts }
+
+  return { bucketedForecasts }
 }


### PR DESCRIPTION
Calibration chart dots now plot at the actual mean predicted probability within each bin, rather than at the bin end. This accurately shows where forecasts actually fall (e.g., if forecasts in the 50-60% bin average 54.3%, the dot plots at 54.3%, not at the bin end of 50%)