### PR TITLE
fix: enable email sign-in over HTTP in local Docker dev

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+.next
+.git
+.env
+*.log
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM node:20-alpine AS base
+RUN apk add --no-cache openssl
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+
+# Development stage — source is mounted as a volume at runtime
+FROM base AS development
+EXPOSE 3000
+
+# Production builder
+FROM base AS builder
+COPY . .
+RUN npx prisma generate --no-hints && npm run build
+
+# Production runner
+FROM node:20-alpine AS production
+RUN apk add --no-cache openssl
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=builder /app/public ./public
+COPY --from=builder /app/.next ./.next
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/package.json ./package.json
+COPY --from=builder /app/prisma ./prisma
+EXPOSE 3000
+CMD ["sh", "-c", "npx prisma migrate deploy && npm start"]

--- a/README.md
+++ b/README.md
@@ -30,7 +30,28 @@ Share your own API creations in [Discord](https://discord.gg/mt9YVB8VDE)!
 
 If you're interested in contributing, [let us know](https://github.com/Sage-Future/fatebook/issues), and we can help you get up and running - thank you!
 
-These following instructions assume you're using macOS and Homebrew.
+### Using Docker
+
+The easiest way to get a local dev environment running:
+
+```shell
+git clone https://github.com/Sage-Future/fatebook.git
+cd fatebook
+cp .env.example .env
+docker compose up
+```
+
+The app will be available at http://localhost:3000. The database is created automatically and migrations run on startup.
+
+**Signing in:** Use the email magic link option. Add `AUTH_EMAIL_SERVER` and `AUTH_EMAIL_FROM` to your `.env` to configure an SMTP server, or see the next section for a zero-config mail catcher.
+
+**Signing in without any external services:** Add a local mail catcher to `docker-compose.yml` — see [Mailpit](https://mailpit.axllent.org/) for a simple option.
+
+**Note:** The local dev SSL proxy is skipped in Docker, so the app runs on plain HTTP. The `.env.example` shared Google OAuth credentials require HTTPS and won't work; either set up your own OAuth credentials with `http://localhost:3000` redirect URIs, or use the email provider instead.
+
+---
+
+The following instructions assume you're using macOS and Homebrew.
 
 ### Clone the repository
 

--- a/README.md
+++ b/README.md
@@ -43,9 +43,7 @@ docker compose up
 
 The app will be available at http://localhost:3000. The database is created automatically and migrations run on startup.
 
-**Signing in:** Use the email magic link option. Add `AUTH_EMAIL_SERVER` and `AUTH_EMAIL_FROM` to your `.env` to configure an SMTP server, or see the next section for a zero-config mail catcher.
-
-**Signing in without any external services:** Add a local mail catcher to `docker-compose.yml` — see [Mailpit](https://mailpit.axllent.org/) for a simple option.
+**Signing in:** Use the email magic link option. Docker Compose includes [Mailpit](https://mailpit.axllent.org/) as a local mail catcher — check http://localhost:8025 to see the sign-in email after requesting one. No SMTP account needed.
 
 **Note:** The local dev SSL proxy is skipped in Docker, so the app runs on plain HTTP. The `.env.example` shared Google OAuth credentials require HTTPS and won't work; either set up your own OAuth credentials with `http://localhost:3000` redirect URIs, or use the email provider instead.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,10 @@
 services:
+  mail:
+    image: axllent/mailpit:latest
+    ports:
+      - "1025:1025"  # SMTP
+      - "8025:8025"  # Web UI
+
   db:
     image: postgres:16-alpine
     environment:
@@ -30,6 +36,9 @@ services:
       # HTTP (no SSL proxy in Docker)
       NEXTAUTH_URL: http://localhost:3000/api/auth
       HOST_URL: http://localhost:3000
+      # Local mail catcher — view sent emails at http://localhost:8025
+      AUTH_EMAIL_SERVER: smtp://mail:1025
+      AUTH_EMAIL_FROM: fatebook@localhost
     volumes:
       - .:/app
       - /app/node_modules  # preserve node_modules installed in image

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,46 @@
+services:
+  db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: fatebook
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: fatebook_development
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U fatebook -d fatebook_development"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  app:
+    build:
+      context: .
+      target: development
+    ports:
+      - "3000:3000"
+    env_file:
+      - .env
+    environment:
+      # Override DB URLs to point to the compose db service instead of localhost
+      DATABASE_URL: postgresql://fatebook:postgres@db:5432/fatebook_development
+      DATABASE_DIRECT_URL: postgresql://fatebook:postgres@db:5432/fatebook_development
+      # HTTP (no SSL proxy in Docker)
+      NEXTAUTH_URL: http://localhost:3000/api/auth
+      HOST_URL: http://localhost:3000
+    volumes:
+      - .:/app
+      - /app/node_modules  # preserve node_modules installed in image
+      - /app/.next         # preserve Next.js build cache
+    depends_on:
+      db:
+        condition: service_healthy
+    command: >
+      sh -c "npx prisma generate --no-hints &&
+             npx prisma migrate deploy &&
+             npx next dev -p 3000"
+
+volumes:
+  postgres_data:

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -17,15 +17,16 @@ function getCookies() {
     https://github.com/nextauthjs/next-auth/blob/c0f9af4c567a905c9d55b732cc0610d44fbae5a6/packages/next-auth/src/core/init.ts#L77
   */
 
-  const useSecureCookies = true
+  const useSecureCookies = process.env.NODE_ENV === "production"
   const cookiePrefix = useSecureCookies ? "__Secure-" : ""
+  const sameSite = useSecureCookies ? ("none" as "none") : ("lax" as "lax")
 
   return {
     sessionToken: {
       name: `${cookiePrefix}next-auth.session-token`,
       options: {
         httpOnly: true,
-        sameSite: "none" as "none",
+        sameSite,
         path: "/",
         secure: useSecureCookies,
       },
@@ -34,7 +35,7 @@ function getCookies() {
       name: `${cookiePrefix}next-auth.callback-url`,
       options: {
         httpOnly: true,
-        sameSite: "none" as "none",
+        sameSite,
         path: "/",
         secure: useSecureCookies,
       },
@@ -45,7 +46,7 @@ function getCookies() {
       name: `${useSecureCookies ? "__Host-" : ""}next-auth.csrf-token`,
       options: {
         httpOnly: true,
-        sameSite: "none" as "none",
+        sameSite,
         path: "/",
         secure: useSecureCookies,
       },
@@ -54,7 +55,7 @@ function getCookies() {
       name: `${cookiePrefix}next-auth.pkce.code_verifier`,
       options: {
         httpOnly: true,
-        sameSite: "none" as "none",
+        sameSite,
         path: "/",
         secure: useSecureCookies,
         maxAge: 60 * 15, // 15 minutes in seconds
@@ -64,7 +65,7 @@ function getCookies() {
       name: `${cookiePrefix}next-auth.state`,
       options: {
         httpOnly: true,
-        sameSite: "none" as "none",
+        sameSite,
         path: "/",
         secure: useSecureCookies,
         maxAge: 60 * 15, // 15 minutes in seconds
@@ -74,7 +75,7 @@ function getCookies() {
       name: `${cookiePrefix}next-auth.nonce`,
       options: {
         httpOnly: true,
-        sameSite: "none" as "none",
+        sameSite,
         path: "/",
         secure: useSecureCookies,
       },
@@ -158,7 +159,7 @@ export const authOptions: NextAuthOptions = {
   jwt: {
     secret: process.env.SECRET,
   },
-  useSecureCookies: true,
+  useSecureCookies: process.env.NODE_ENV === "production",
 
   cookies: getCookies(),
 


### PR DESCRIPTION
This is a stacked PR[^1]. Only review commit [6b86965](https://github.com/Sage-Future/fatebook/pull/107/commits/6b86965700d0c56626285e9552e546fc1752af8c).

PRs:
* ➡️ #107 (this PR, depends on the ones below ⬇️)
* #106

---

## Description

NextAuth secure cookies and HTTPS were required even locally, blocking
email magic link login without a real SSL setup. Make secure cookies
conditional on production, and add Mailpit to docker-compose so devs
can sign in with zero external dependencies.

[^1]: A stacked PR is a pull request that depends on other pull requests. The current PR depends on the ones listed below it and MUST NOT be merged before they are merged. The PRs listed above the current one in turn depend on it and won't be merged until the current one is. Learn more about [why](https://github.com/omarkohl/jip/blob/main/docs/why.md) and [how to review](https://github.com/omarkohl/jip/blob/main/docs/reviewing.md).
